### PR TITLE
Kotlin Language Adapter (1.12-)

### DIFF
--- a/versions/1.12.2-forge/api/1.12.2-forge.api
+++ b/versions/1.12.2-forge/api/1.12.2-forge.api
@@ -76,6 +76,14 @@ public class cc/polyfrost/oneconfig/platform/impl/ServerPlatformImpl : cc/polyfr
 	public fun inMultiplayer ()Z
 }
 
+public final class cc/polyfrost/oneconfig/utils/KotlinLanguageAdapter : net/minecraftforge/fml/common/ILanguageAdapter {
+	public fun <init> ()V
+	public fun getNewInstance (Lnet/minecraftforge/fml/common/FMLModContainer;Ljava/lang/Class;Ljava/lang/ClassLoader;Ljava/lang/reflect/Method;)Ljava/lang/Object;
+	public fun setInternalProxies (Lnet/minecraftforge/fml/common/ModContainer;Lnet/minecraftforge/fml/relauncher/Side;Ljava/lang/ClassLoader;)V
+	public fun setProxy (Ljava/lang/reflect/Field;Ljava/lang/Class;Ljava/lang/Object;)V
+	public fun supportsStatics ()Z
+}
+
 public class cc/polyfrost/oneconfig/utils/commands/PlatformCommandManagerImpl : cc/polyfrost/oneconfig/utils/commands/PlatformCommandManager {
 	public fun <init> ()V
 	public fun createCommand (Lcc/polyfrost/oneconfig/utils/commands/CommandManager$InternalCommand;Lcc/polyfrost/oneconfig/utils/commands/annotations/Command;)V

--- a/versions/1.8.9-forge/api/1.8.9-forge.api
+++ b/versions/1.8.9-forge/api/1.8.9-forge.api
@@ -76,6 +76,14 @@ public class cc/polyfrost/oneconfig/platform/impl/ServerPlatformImpl : cc/polyfr
 	public fun inMultiplayer ()Z
 }
 
+public final class cc/polyfrost/oneconfig/utils/KotlinLanguageAdapter : net/minecraftforge/fml/common/ILanguageAdapter {
+	public fun <init> ()V
+	public fun getNewInstance (Lnet/minecraftforge/fml/common/FMLModContainer;Ljava/lang/Class;Ljava/lang/ClassLoader;Ljava/lang/reflect/Method;)Ljava/lang/Object;
+	public fun setInternalProxies (Lnet/minecraftforge/fml/common/ModContainer;Lnet/minecraftforge/fml/relauncher/Side;Ljava/lang/ClassLoader;)V
+	public fun setProxy (Ljava/lang/reflect/Field;Ljava/lang/Class;Ljava/lang/Object;)V
+	public fun supportsStatics ()Z
+}
+
 public class cc/polyfrost/oneconfig/utils/commands/PlatformCommandManagerImpl : cc/polyfrost/oneconfig/utils/commands/PlatformCommandManager {
 	public fun <init> ()V
 	public fun createCommand (Lcc/polyfrost/oneconfig/utils/commands/CommandManager$InternalCommand;Lcc/polyfrost/oneconfig/utils/commands/annotations/Command;)V

--- a/versions/src/main/kotlin/cc/polyfrost/oneconfig/utils/KotlinLanguageAdapter.kt
+++ b/versions/src/main/kotlin/cc/polyfrost/oneconfig/utils/KotlinLanguageAdapter.kt
@@ -1,0 +1,36 @@
+//#if MC<=11202
+package cc.polyfrost.oneconfig.utils
+
+import net.minecraftforge.fml.common.FMLModContainer
+import net.minecraftforge.fml.common.ILanguageAdapter
+import net.minecraftforge.fml.common.ModContainer
+import net.minecraftforge.fml.relauncher.Side
+import java.lang.reflect.Field
+import java.lang.reflect.Method
+
+/**
+ * An adapter for FML to allow for the use of Kotlin objects as a mod class.
+ * This is not required if you use a Kotlin class, only if you use a Kotlin object.
+ *
+ * Taken from Crimson under LGPL 3.0
+ * https://github.com/Deftu-Archive/Crimson/blob/main/LICENSE
+ */
+class KotlinLanguageAdapter : ILanguageAdapter {
+
+    override fun supportsStatics(): Boolean = false
+    override fun getNewInstance(
+        container: FMLModContainer,
+        objectClass: Class<*>,
+        classLoader: ClassLoader,
+        factoryMarkedAnnotation: Method
+    ): Any = objectClass.kotlin.objectInstance ?: objectClass.getDeclaredConstructor().newInstance()
+
+    override fun setProxy(target: Field, proxyTarget: Class<*>, proxy: Any) {
+        target.set(proxyTarget.kotlin.objectInstance, proxy)
+    }
+
+    override fun setInternalProxies(mod: ModContainer?, side: Side?, loader: ClassLoader?) {
+    }
+
+}
+//#endif

--- a/versions/src/main/kotlin/cc/polyfrost/oneconfig/utils/KotlinLanguageAdapter.kt
+++ b/versions/src/main/kotlin/cc/polyfrost/oneconfig/utils/KotlinLanguageAdapter.kt
@@ -12,17 +12,14 @@ import java.lang.reflect.Method
  * An adapter for FML to allow for the use of Kotlin objects as a mod class.
  * This is not required if you use a Kotlin class, only if you use a Kotlin object.
  *
- * Taken from Crimson under LGPL 3.0
+ * Adapted from Crimson under LGPL 3.0
  * https://github.com/Deftu-Archive/Crimson/blob/main/LICENSE
  */
 class KotlinLanguageAdapter : ILanguageAdapter {
 
     override fun supportsStatics(): Boolean = false
     override fun getNewInstance(
-        container: FMLModContainer,
-        objectClass: Class<*>,
-        classLoader: ClassLoader,
-        factoryMarkedAnnotation: Method
+        container: FMLModContainer, objectClass: Class<*>, classLoader: ClassLoader, factoryMarkedAnnotation: Method
     ): Any = objectClass.kotlin.objectInstance ?: objectClass.getDeclaredConstructor().newInstance()
 
     override fun setProxy(target: Field, proxyTarget: Class<*>, proxy: Any) {


### PR DESCRIPTION
## Description
"An adapter for FML to allow for the use of Kotlin objects as a mod class. This is not required if you use a Kotlin class, only if you use a Kotlin object."

## Related Issue(s)
n/a

## Checklist
- [x] I made a clear description of what was changed
- [x] I stated why these changes were necessary
- [x] I updated documentation or said what needs to be updated
- [x] I made sure these changes are backwards compatible
- [x] This pull request is for one feature/bug fix
