### PR TITLE
Help subcommand impovments

### DIFF
--- a/api/OneConfig.api
+++ b/api/OneConfig.api
@@ -1323,6 +1323,7 @@ public abstract class cc/polyfrost/oneconfig/utils/commands/PlatformCommandManag
 
 public abstract interface annotation class cc/polyfrost/oneconfig/utils/commands/annotations/Command : java/lang/annotation/Annotation {
 	public abstract fun aliases ()[Ljava/lang/String;
+	public abstract fun color ()Lcc/polyfrost/oneconfig/libs/universal/ChatColor;
 	public abstract fun description ()Ljava/lang/String;
 	public abstract fun helpCommand ()Z
 	public abstract fun value ()Ljava/lang/String;
@@ -1342,6 +1343,7 @@ public abstract interface annotation class cc/polyfrost/oneconfig/utils/commands
 
 public abstract interface annotation class cc/polyfrost/oneconfig/utils/commands/annotations/SubCommand : java/lang/annotation/Annotation {
 	public abstract fun aliases ()[Ljava/lang/String;
+	public abstract fun color ()Lcc/polyfrost/oneconfig/libs/universal/ChatColor;
 	public abstract fun description ()Ljava/lang/String;
 	public abstract fun value ()Ljava/lang/String;
 }

--- a/src/main/java/cc/polyfrost/oneconfig/utils/commands/CommandManager.java
+++ b/src/main/java/cc/polyfrost/oneconfig/utils/commands/CommandManager.java
@@ -1,5 +1,6 @@
 package cc.polyfrost.oneconfig.utils.commands;
 
+import cc.polyfrost.oneconfig.libs.universal.ChatColor;
 import cc.polyfrost.oneconfig.utils.commands.annotations.Command;
 import cc.polyfrost.oneconfig.utils.commands.annotations.Main;
 import cc.polyfrost.oneconfig.utils.commands.annotations.SubCommand;
@@ -63,7 +64,8 @@ public class CommandManager {
         if (clazz.isAnnotationPresent(Command.class)) {
             final Command annotation = clazz.getAnnotation(Command.class);
 
-            final InternalCommand root = new InternalCommand(annotation.value(), annotation.aliases(), annotation.description().trim().isEmpty() ? "Main command for " + annotation.value() : annotation.description(), null);
+            final InternalCommand root = new InternalCommand(annotation.value(), annotation.aliases(), annotation.description().trim().isEmpty()
+                    ? "Main command for " + annotation.value() : annotation.description(), annotation.color(),  null);
             for (Method method : clazz.getDeclaredMethods()) {
                 if (method.isAnnotationPresent(Main.class) && method.getParameterCount() == 0) {
                     root.invokers.add(new InternalCommand.InternalCommandInvoker(annotation.value(), annotation.aliases(), method, root));
@@ -79,7 +81,7 @@ public class CommandManager {
         for (Class<?> clazz : classes) {
             if (clazz.isAnnotationPresent(SubCommand.class)) {
                 SubCommand annotation = clazz.getAnnotation(SubCommand.class);
-                InternalCommand command = new InternalCommand(annotation.value(), annotation.aliases(), annotation.description(), parent);
+                InternalCommand command = new InternalCommand(annotation.value(), annotation.aliases(), annotation.description(), annotation.color() == ChatColor.RESET ? parent.color : annotation.color(), parent);
                 for (Method method : clazz.getDeclaredMethods()) {
                     if (method.isAnnotationPresent(Main.class)) {
                         command.invokers.add(new InternalCommand.InternalCommandInvoker(annotation.value(), annotation.aliases(), method, command));
@@ -103,15 +105,17 @@ public class CommandManager {
         public final String name;
         public final String[] aliases;
         public final String description;
+        public final ChatColor color;
         public final ArrayList<InternalCommandInvoker> invokers = new ArrayList<>();
         public final InternalCommand parent;
         public final ArrayList<InternalCommand> children = new ArrayList<>();
 
-        public InternalCommand(String name, String[] aliases, String description, InternalCommand parent) {
+        public InternalCommand(String name, String[] aliases, String description, ChatColor color, InternalCommand parent) {
             this.name = name;
             this.aliases = aliases;
             this.description = description;
             this.parent = parent;
+            this.color = color;
         }
 
         public boolean isValid(String name, boolean tabCompletion) {

--- a/src/main/java/cc/polyfrost/oneconfig/utils/commands/PlatformCommandManager.java
+++ b/src/main/java/cc/polyfrost/oneconfig/utils/commands/PlatformCommandManager.java
@@ -13,14 +13,14 @@ public abstract class PlatformCommandManager {
     //TODO: someone make the help command actually look nice lmao
     protected String sendHelpCommand(CommandManager.InternalCommand root) {
         StringBuilder builder = new StringBuilder();
-        builder.append(ChatColor.GOLD).append("Help for ").append(ChatColor.BOLD).append(root.name).append(ChatColor.RESET).append(ChatColor.GOLD).append(":\n");
-        if (!root.description.isEmpty()) {
-            builder.append("\n").append(ChatColor.GOLD).append("Description: ").append(ChatColor.BOLD).append(root.description);
-        }
+        builder.append(root.color).append("Help for ").append(ChatColor.BOLD).append(root.name).append(ChatColor.RESET).append(root.color).append(":\n");
+       if (!root.description.isEmpty()) {
+           builder.append("\n").append(root.color).append("/").append(root.name).append(": ").append(ChatColor.BOLD).append(root.description);
+       }
         for (CommandManager.InternalCommand command : root.children) {
             runThroughCommandsHelp(root.name, command, builder);
         }
-        builder.append("\n").append(ChatColor.GOLD).append("Aliases: ").append(ChatColor.BOLD);
+        builder.append("\n \n").append(root.color).append("Aliases: ").append(ChatColor.BOLD);
         int index = 0;
         for (String alias : root.aliases) {
             ++index;
@@ -36,12 +36,12 @@ public abstract class PlatformCommandManager {
             if (declaringClass.isAnnotationPresent(SubCommand.class)) {
                 String description = declaringClass.getAnnotation(SubCommand.class).description();
                 if (!description.isEmpty()) {
-                    builder.append("\n").append(ChatColor.GOLD).append("Description: ").append(ChatColor.BOLD).append(description);
+                    builder.append("\n");
                 }
             }
         }
         for (CommandManager.InternalCommand.InternalCommandInvoker invoker : command.invokers) {
-            builder.append("\n").append(ChatColor.GOLD).append("/").append(append).append(" ").append(command.name);
+            builder.append("\n").append(command.color).append("/").append(append).append(" ").append(command.name);
             for (Parameter parameter : invoker.method.getParameters()) {
                 String name = parameter.getName();
                 if (parameter.isAnnotationPresent(Name.class)) {

--- a/src/main/java/cc/polyfrost/oneconfig/utils/commands/PlatformCommandManager.java
+++ b/src/main/java/cc/polyfrost/oneconfig/utils/commands/PlatformCommandManager.java
@@ -13,18 +13,19 @@ public abstract class PlatformCommandManager {
     //TODO: someone make the help command actually look nice lmao
     protected String sendHelpCommand(CommandManager.InternalCommand root) {
         StringBuilder builder = new StringBuilder();
-        builder.append(root.color).append("Help for ").append(ChatColor.BOLD).append(root.name).append(ChatColor.RESET).append(root.color).append(":\n");
+        builder.append(root.color).append("Help for ").append(ChatColor.BOLD).append(root.name).append(ChatColor.RESET).append(root.color);
+        int index = 0;
+        for (String alias : root.aliases) {
+            if(index == 0) builder.append("(");
+            ++index;
+            builder.append("/").append(alias).append(index < root.aliases.length ? ", " : ")");
+        }
+        builder.append(":\n");
        if (!root.description.isEmpty()) {
            builder.append("\n").append(root.color).append("/").append(root.name).append(": ").append(ChatColor.BOLD).append(root.description);
        }
         for (CommandManager.InternalCommand command : root.children) {
             runThroughCommandsHelp(root.name, command, builder);
-        }
-        builder.append("\n \n").append(root.color).append("Aliases: ").append(ChatColor.BOLD);
-        int index = 0;
-        for (String alias : root.aliases) {
-            ++index;
-            builder.append(alias).append(index < root.aliases.length ? ", " : "");
         }
         builder.append("\n");
         return builder.toString();
@@ -49,8 +50,14 @@ public abstract class PlatformCommandManager {
                 }
                 builder.append(" <").append(name).append(">");
             }
+            int index = 0;
+            for (String alias : command.aliases) {
+                if(index == 0) builder.append("(");
+                ++index;
+                builder.append(alias).append(index < command.aliases.length ? ", " : ")");
+            }
             if (!command.description.trim().isEmpty()) {
-                builder.append(": ").append(ChatColor.BOLD).append(command.description);
+                builder.append(": ").append(ChatColor.BOLD).append(command.color).append(command.description);
             }
         }
         for (CommandManager.InternalCommand subCommand : command.children) {

--- a/src/main/java/cc/polyfrost/oneconfig/utils/commands/PlatformCommandManager.java
+++ b/src/main/java/cc/polyfrost/oneconfig/utils/commands/PlatformCommandManager.java
@@ -16,7 +16,7 @@ public abstract class PlatformCommandManager {
         builder.append(root.color).append("Help for ").append(ChatColor.BOLD).append(root.name).append(ChatColor.RESET).append(root.color);
         int index = 0;
         for (String alias : root.aliases) {
-            if(index == 0) builder.append("(");
+            if(index == 0) builder.append(" (");
             ++index;
             builder.append("/").append(alias).append(index < root.aliases.length ? ", " : ")");
         }
@@ -52,7 +52,7 @@ public abstract class PlatformCommandManager {
             }
             int index = 0;
             for (String alias : command.aliases) {
-                if(index == 0) builder.append("(");
+                if(index == 0) builder.append(" (");
                 ++index;
                 builder.append(alias).append(index < command.aliases.length ? ", " : ")");
             }

--- a/src/main/java/cc/polyfrost/oneconfig/utils/commands/annotations/Command.java
+++ b/src/main/java/cc/polyfrost/oneconfig/utils/commands/annotations/Command.java
@@ -1,6 +1,7 @@
 package cc.polyfrost.oneconfig.utils.commands.annotations;
 
 import cc.polyfrost.oneconfig.internal.command.OneConfigCommand;
+import cc.polyfrost.oneconfig.libs.universal.ChatColor;
 import cc.polyfrost.oneconfig.utils.commands.CommandManager;
 import cc.polyfrost.oneconfig.utils.commands.arguments.ArgumentParser;
 
@@ -106,6 +107,13 @@ public @interface Command {
      * @return The description of the command.
      */
     String description() default "";
+
+    /**
+     * The color of the command.
+     *
+     * @return The color of the command.
+     */
+    ChatColor color() default ChatColor.GOLD;
 
     /**
      * Whether the command generates a help command.

--- a/src/main/java/cc/polyfrost/oneconfig/utils/commands/annotations/SubCommand.java
+++ b/src/main/java/cc/polyfrost/oneconfig/utils/commands/annotations/SubCommand.java
@@ -1,5 +1,7 @@
 package cc.polyfrost.oneconfig.utils.commands.annotations;
 
+import cc.polyfrost.oneconfig.libs.universal.ChatColor;
+
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
@@ -34,4 +36,11 @@ public @interface SubCommand {
      * @return The description of the command.
      */
     String description() default "";
+
+    /**
+     * The color of the command.
+     *
+     * @return The color of the command.
+     */
+    ChatColor color() default ChatColor.RESET;
 }


### PR DESCRIPTION
Improved the default "help" SubCommand
## Description
<!-- Describe your changes in detail -->
The default help SubCommand looked awful, so i changed how the command looks in general, i also added the "color" to `@Command` and `@SubCommand` which takes in ChatColor.
if the color field is not provided in `@Command`, the default color will be GOLD, if the color field is not provided in `@SubCommand`. the default color will be the color of `@Command`

im making a PR to hud-improvments as that was the branch i used to build it on, wasnt sure what other one to use

Before:
![unknown](https://user-images.githubusercontent.com/56201697/179568880-e8140b81-018f-4ac7-9799-b7a04058fcfe.png)

After:
![unknown](https://user-images.githubusercontent.com/56201697/179568951-354703d8-7b7e-4148-ad3f-79ed8729e7c7.png)

With Color applied(just an example, i didn't do this to the OneConfig command):
![unknown](https://user-images.githubusercontent.com/56201697/179569103-77916f51-b5f0-41aa-96dc-6e1a9101f18f.png)

## Checklist
- [x] I made a clear description of what was changed
- [x] I stated why these changes were necessary
- [ ] I updated documentation or said what needs to be updated
- [x] I made sure these changes are backwards compatible
- [x] This pull request is for one feature/bug fix
