### PR TITLE
new: add base for notifications api

### DIFF
--- a/api/OneConfig.api
+++ b/api/OneConfig.api
@@ -1599,3 +1599,24 @@ public final class cc/polyfrost/oneconfig/utils/hypixel/LocrawInfo$GameType : ja
 	public static fun values ()[Lcc/polyfrost/oneconfig/utils/hypixel/LocrawInfo$GameType;
 }
 
+public final class cc/polyfrost/oneconfig/utils/notifications/Notification {
+	public fun getAction ()Ljava/lang/Runnable;
+	public fun getDuration ()F
+	public fun getMessage ()Ljava/lang/String;
+	public fun getOnClose ()Ljava/lang/Runnable;
+	public fun getTitle ()Ljava/lang/String;
+	public fun getX ()F
+	public fun getY ()F
+	public fun setMessage (Ljava/lang/String;)V
+	public fun setTitle (Ljava/lang/String;)V
+}
+
+public final class cc/polyfrost/oneconfig/utils/notifications/Notifications {
+	public static final field INSTANCE Lcc/polyfrost/oneconfig/utils/notifications/Notifications;
+	public fun send (Ljava/lang/String;Ljava/lang/String;)V
+	public fun send (Ljava/lang/String;Ljava/lang/String;F)V
+	public fun send (Ljava/lang/String;Ljava/lang/String;FLjava/lang/Runnable;)V
+	public fun send (Ljava/lang/String;Ljava/lang/String;FLjava/lang/Runnable;Ljava/lang/Runnable;)V
+	public fun send (Ljava/lang/String;Ljava/lang/String;Ljava/lang/Runnable;)V
+}
+

--- a/src/main/java/cc/polyfrost/oneconfig/utils/notifications/Notification.java
+++ b/src/main/java/cc/polyfrost/oneconfig/utils/notifications/Notification.java
@@ -1,0 +1,74 @@
+package cc.polyfrost.oneconfig.utils.notifications;
+
+/**
+ * @deprecated Reserved for future use, not implemented yet.
+ */
+@Deprecated
+public final class Notification {
+    private String title;
+    private String message;
+    private final float duration;
+    private float x;
+    private float y;
+
+    private final Runnable action;
+    private final Runnable onClose;
+
+    Notification(String title, String message, float duration, float x, float y, Runnable action, Runnable onClose) {
+        this.title = title;
+        this.message = message;
+        this.duration = duration;
+        this.x = x;
+        this.y = y;
+        this.action = action;
+        this.onClose = onClose;
+    }
+
+    void draw(final long vg) {
+
+    }
+
+    public String getTitle() {
+        return title;
+    }
+
+    public String getMessage() {
+        return message;
+    }
+
+    public float getDuration() {
+        return duration;
+    }
+
+    public float getX() {
+        return x;
+    }
+
+    public float getY() {
+        return y;
+    }
+
+    public Runnable getAction() {
+        return action;
+    }
+
+    public Runnable getOnClose() {
+        return onClose;
+    }
+
+    public void setTitle(String title) {
+        this.title = title;
+    }
+
+    public void setMessage(String message) {
+        this.message = message;
+    }
+
+    void setX(float x) {
+        this.x = x;
+    }
+
+    void setY(float y) {
+        this.y = y;
+    }
+}

--- a/src/main/java/cc/polyfrost/oneconfig/utils/notifications/Notifications.java
+++ b/src/main/java/cc/polyfrost/oneconfig/utils/notifications/Notifications.java
@@ -1,0 +1,32 @@
+package cc.polyfrost.oneconfig.utils.notifications;
+
+/**
+ * @deprecated Reserved for future use, not implemented yet.
+ */
+@Deprecated
+public final class Notifications {
+    public static final Notifications INSTANCE = new Notifications();
+    private Notifications() {
+
+    }
+
+    public void send(String title, String message) {
+
+    }
+
+    public void send(String title, String message, Runnable action) {
+
+    }
+
+    public void send(String title, String message, float duration) {
+
+    }
+
+    public void send(String title, String message, float duration, Runnable action) {
+
+    }
+
+    public void send(String title, String message, float duration, Runnable action, Runnable onClose) {
+
+    }
+}


### PR DESCRIPTION
## Description
This adds the base for a Notifications API in OneConfig.
Although we are currently awaiting a design for notifications, it is useful to have this code before we actually implement it as many mods migrating from Essential to OneConfig use notifications.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->

## Checklist
- [x] I made a clear description of what was changed
- [x] I stated why these changes were necessary
- [x] I updated documentation or said what needs to be updated
- [x] I made sure these changes are backwards compatible
- [x] This pull request is for one feature/bug fix

**CONTRIBUTORS / REVIEWERS**: Please actually check what is included in the API and see if things such as namings are up to standard 