### PR TITLE
misc: update workflow to publish all versions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,7 +49,7 @@ jobs:
         id: version
 
       - name: Publish
-        run: ./gradlew platform:1.8.9-forge:publishOneconfig-1.8.9-forgePublicationToReleasesRepository -Pmod_minor_version=${{ steps.version.outputs.VERSION_NUMBER }} -PreleasesUsername=${{ secrets.MAVEN_NAME }} -PreleasesPassword=${{ secrets.MAVEN_TOKEN }} --no-daemon
+        run: ./gradlew platform:publishAllPublicationsToReleasesRepository -Pmod_minor_version=${{ steps.version.outputs.VERSION_NUMBER }} -PreleasesUsername=${{ secrets.MAVEN_NAME }} -PreleasesPassword=${{ secrets.MAVEN_TOKEN }} --no-daemon
 
       - name: Upload Build Artifacts
         uses: actions/upload-artifact@v2


### PR DESCRIPTION
## Description
This updates the workflow to run `publishAllPublicationsToReleasesRepository` instead of the 1.8.9 specific task.

## Related Issue(s)

## Checklist
- [x] I made a clear description of what was changed
- [x] I stated why these changes were necessary
- [x] I updated documentation or said what needs to be updated
- [x] I made sure these changes are backwards compatible
- [x] This pull request is for one feature/bug fix
