### PR TITLE
integrate with forge chat event

### DIFF
--- a/versions/1.12.2-forge/src/main/java/cc/polyfrost/oneconfig/internal/mixin/EventBusMixin.java
+++ b/versions/1.12.2-forge/src/main/java/cc/polyfrost/oneconfig/internal/mixin/EventBusMixin.java
@@ -24,6 +24,7 @@
  * <https://polyfrost.cc/legal/oneconfig/additional-terms>
  */
 
+//#if FORGE==1
 package cc.polyfrost.oneconfig.internal.mixin;
 
 import cc.polyfrost.oneconfig.events.EventManager;
@@ -53,3 +54,5 @@ public class EventBusMixin {
         }
     }
 }
+
+//#endif

--- a/versions/1.12.2-forge/src/main/java/cc/polyfrost/oneconfig/internal/mixin/EventBusMixin.java
+++ b/versions/1.12.2-forge/src/main/java/cc/polyfrost/oneconfig/internal/mixin/EventBusMixin.java
@@ -24,7 +24,6 @@
  * <https://polyfrost.cc/legal/oneconfig/additional-terms>
  */
 
-//#if MC==10809
 package cc.polyfrost.oneconfig.internal.mixin;
 
 import cc.polyfrost.oneconfig.events.EventManager;

--- a/versions/1.12.2-forge/src/main/java/cc/polyfrost/oneconfig/internal/mixin/EventBusMixin.java
+++ b/versions/1.12.2-forge/src/main/java/cc/polyfrost/oneconfig/internal/mixin/EventBusMixin.java
@@ -24,27 +24,32 @@
  * <https://polyfrost.cc/legal/oneconfig/additional-terms>
  */
 
+//#if MC==10809
 package cc.polyfrost.oneconfig.internal.mixin;
 
 import cc.polyfrost.oneconfig.events.EventManager;
 import cc.polyfrost.oneconfig.events.event.ChatReceiveEvent;
-import net.minecraft.client.network.NetHandlerPlayClient;
-import net.minecraft.network.play.server.SPacketChat;
+import net.minecraft.util.text.ChatType;
+import net.minecraftforge.client.event.ClientChatReceivedEvent;
+import net.minecraftforge.fml.common.eventhandler.Event;
+import net.minecraftforge.fml.common.eventhandler.EventBus;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
-import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
-@Mixin(value = NetHandlerPlayClient.class, priority = Integer.MAX_VALUE)
-public class NetHandlerPlayClientMixin {
+@Mixin(EventBus.class)
+public class EventBusMixin {
 
-    @Inject(method = "handleChat", at = @At(value = "INVOKE", target = "Lnet/minecraftforge/event/ForgeEventFactory;onClientChat(Lnet/minecraft/util/text/ChatType;Lnet/minecraft/util/text/ITextComponent;)Lnet/minecraft/util/text/ITextComponent;", remap = false), cancellable = true, remap = true)
-    private void onClientChat(SPacketChat packetIn, CallbackInfo ci) {
-        if (packetIn.getType().getId() == 0) {
-            ChatReceiveEvent event = new ChatReceiveEvent(packetIn.getChatComponent());
-            EventManager.INSTANCE.post(event);
-            if (event.isCancelled) {
-                ci.cancel();
+    @Inject(method = "post", at = @At(value = "HEAD"), remap = false)
+    private void post(Event e, CallbackInfoReturnable<Boolean> cir) {
+        if(!(e instanceof ClientChatReceivedEvent)) return;
+        ClientChatReceivedEvent event = (ClientChatReceivedEvent) e;
+        if (event.getType() == ChatType.CHAT) {
+            ChatReceiveEvent customEvent = new ChatReceiveEvent(event.getMessage());
+            EventManager.INSTANCE.post(customEvent);
+            if (customEvent.isCancelled) {
+                e.setCanceled(true);
             }
         }
     }

--- a/versions/1.16.2-forge/src/main/java/cc/polyfrost/oneconfig/internal/mixin/EventBusMixin.java
+++ b/versions/1.16.2-forge/src/main/java/cc/polyfrost/oneconfig/internal/mixin/EventBusMixin.java
@@ -24,7 +24,6 @@
  * <https://polyfrost.cc/legal/oneconfig/additional-terms>
  */
 
-//#if MC==10809
 package cc.polyfrost.oneconfig.internal.mixin;
 
 import cc.polyfrost.oneconfig.events.EventManager;

--- a/versions/1.16.2-forge/src/main/java/cc/polyfrost/oneconfig/internal/mixin/EventBusMixin.java
+++ b/versions/1.16.2-forge/src/main/java/cc/polyfrost/oneconfig/internal/mixin/EventBusMixin.java
@@ -24,27 +24,32 @@
  * <https://polyfrost.cc/legal/oneconfig/additional-terms>
  */
 
+//#if MC==10809
 package cc.polyfrost.oneconfig.internal.mixin;
 
 import cc.polyfrost.oneconfig.events.EventManager;
 import cc.polyfrost.oneconfig.events.event.ChatReceiveEvent;
-import net.minecraft.client.network.play.ClientPlayNetHandler;
-import net.minecraft.network.play.server.SChatPacket;
+import net.minecraft.util.text.ChatType;
+import net.minecraftforge.client.event.ClientChatReceivedEvent;
+import net.minecraftforge.eventbus.EventBus;
+import net.minecraftforge.eventbus.api.Event;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
-import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
-@Mixin(value = ClientPlayNetHandler.class, priority = Integer.MAX_VALUE)
-public class NetHandlerPlayClientMixin {
+@Mixin(EventBus.class)
+public class EventBusMixin {
 
-    @Inject(method = "handleChat", at = @At(value = "INVOKE", target = "Lnet/minecraftforge/event/ForgeEventFactory;onClientChat(Lnet/minecraft/util/text/ChatType;Lnet/minecraft/util/text/ITextComponent;Ljava/util/UUID;)Lnet/minecraft/util/text/ITextComponent;", remap = false), cancellable = true, remap = true)
-    private void onClientChat(SChatPacket packetIn, CallbackInfo ci) {
-        if (packetIn.getType().getId() == 0) {
-            ChatReceiveEvent event = new ChatReceiveEvent(packetIn.getChatComponent());
-            EventManager.INSTANCE.post(event);
-            if (event.isCancelled) {
-                ci.cancel();
+    @Inject(method = "post", at = @At(value = "HEAD"), remap = false)
+    private void post(Event e, CallbackInfoReturnable<Boolean> cir) {
+        if(!(e instanceof ClientChatReceivedEvent)) return;
+        ClientChatReceivedEvent event = (ClientChatReceivedEvent) e;
+        if (event.getType() == ChatType.CHAT) {
+            ChatReceiveEvent customEvent = new ChatReceiveEvent(event.getMessage());
+            EventManager.INSTANCE.post(customEvent);
+            if (customEvent.isCancelled) {
+                e.setCanceled(true);
             }
         }
     }

--- a/versions/1.16.2-forge/src/main/java/cc/polyfrost/oneconfig/internal/mixin/EventBusMixin.java
+++ b/versions/1.16.2-forge/src/main/java/cc/polyfrost/oneconfig/internal/mixin/EventBusMixin.java
@@ -24,6 +24,7 @@
  * <https://polyfrost.cc/legal/oneconfig/additional-terms>
  */
 
+//#if FORGE==1
 package cc.polyfrost.oneconfig.internal.mixin;
 
 import cc.polyfrost.oneconfig.events.EventManager;
@@ -53,3 +54,4 @@ public class EventBusMixin {
         }
     }
 }
+//#endif

--- a/versions/src/main/java/cc/polyfrost/oneconfig/internal/plugin/OneConfigMixinPlugin.java
+++ b/versions/src/main/java/cc/polyfrost/oneconfig/internal/plugin/OneConfigMixinPlugin.java
@@ -67,8 +67,13 @@ public class OneConfigMixinPlugin implements IMixinConfigPlugin {
 
     @Override
     public List<String> getMixins() {
+        ArrayList<String> mixins = new ArrayList<>();
+        if (Platform.getInstance().getLoader().equals(Platform.Loader.FORGE)) {
+            mixins.add("EventBusMixin");
+        } else if (Platform.getInstance().getLoader().equals(Platform.Loader.FABRIC)) {
+            mixins.add("NetHandlerPlayClientMixin");
+        }
         if (Platform.getInstance().getMinecraftVersion() >= 11600) {
-            ArrayList<String> mixins = new ArrayList<>();
             if (Platform.getInstance().getLoader() == Platform.Loader.FORGE) {
                 mixins.add("ClientModLoaderMixin");
             } else {
@@ -80,9 +85,8 @@ public class OneConfigMixinPlugin implements IMixinConfigPlugin {
             mixins.add("MouseMixin");
             mixins.add("TickTimeTrackerMixin");
             return mixins;
-        } else {
-            return null;
         }
+        return mixins.isEmpty() ? null : mixins;
     }
 
     @Override

--- a/versions/src/main/resources/mixins.oneconfig.json
+++ b/versions/src/main/resources/mixins.oneconfig.json
@@ -11,7 +11,6 @@
   "client": [
     "GuiIngameForgeMixin",
     "MinecraftMixin",
-    "NetHandlerPlayClientMixin",
     "NetworkManagerMixin",
     "OptifineConfigMixin",
     "ShaderGroupAccessor",


### PR DESCRIPTION
## Description
Use forge event bus closer so other mods can still get canceled events and chatReceiveEvent gets messages posted by other mods (like skytils)

## Related Issue(s)
<!-- List the issue(s) this PR solves -->

## Checklist
- [X] I made a clear description of what was changed
- [X] I stated why these changes were necessary
- [X] I updated documentation or said what needs to be updated
- [X] I made sure these changes are backwards compatible
- [X] This pull request is for one feature/bug fix
