### PR TITLE
fix yourkit logo

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ Polyfrost acts as the specified proxy when deciding whether future versions of t
 
 <details>
   <summary>Supporting Projects</summary>
+
 ![YourKitLogo|50](https://www.yourkit.com/images/yklogo.png)
 
 YourKit supports open source projects with innovative and intelligent tools


### PR DESCRIPTION
i only make the most insane oneconfig prs

## Description
The YourKit logo was not being displayed properly. This is because there was no newline space between the summary thingy and the logo thingy. I have fixed this by adding in a new line space. This new change now makes the YourKit logo show. This is because by adding the new line it has fixed the issue. The issue is now fixed because of this. The fix in question is adding a new line. The YourKit logo now properly displays. It displays properly because of the new line. This means that the issue has been fixed as the logo now displays. Previously before my fix it was not fixed as it was broken and the YoutKit logo was not displaying. With this fix the YourKit logo is now being actively displayed. This was a very quick fix, as it was only adding a single new line to fix the YourKit logo not displaying. This is because the issue was that there was no empty line so adding it was relatively simple and easy and so that is why it was relatively quick because it was relatively simple and easy to add a new line to fix the YourKit logo not displaying correctly and now it displays correctly. Hopefully this description of how I fixed the YourKit logo not displaying, why the YourKit logo was not displaying, and my reasoning and logic behind my fix to make the YourKit logo display is clear, as well as stating why this change was necessary, as well as why no documentation needs to be updated, as well as why this change is backwards compatible, as well as why this only constitutes as being one feature/bug fix.

Thank you for your time.

## Related Issue(s)
I have many.

## Checklist
- [x] I made a clear description of what was changed
- [x] I stated why these changes were necessary
- [x] I updated documentation or said what needs to be updated
- [x] I made sure these changes are backwards compatible
- [x] This pull request is for one feature/bug fix
