### PR TITLE
fix: duplicate eventmanager registration detection

### DIFF
--- a/api/OneConfig.api
+++ b/api/OneConfig.api
@@ -423,6 +423,7 @@ public abstract interface annotation class cc/polyfrost/oneconfig/config/migrati
 
 public final class cc/polyfrost/oneconfig/events/EventManager {
 	public static final field INSTANCE Lcc/polyfrost/oneconfig/events/EventManager;
+	public fun <init> ()V
 	public fun getEventBus ()Lcc/polyfrost/oneconfig/libs/eventbus/EventBus;
 	public fun post (Ljava/lang/Object;)V
 	public fun register (Ljava/lang/Object;)V

--- a/src/main/java/cc/polyfrost/oneconfig/events/EventManager.java
+++ b/src/main/java/cc/polyfrost/oneconfig/events/EventManager.java
@@ -30,6 +30,8 @@ import cc.polyfrost.oneconfig.config.core.exceptions.InvalidTypeException;
 import cc.polyfrost.oneconfig.libs.eventbus.EventBus;
 import cc.polyfrost.oneconfig.libs.eventbus.exception.ExceptionHandler;
 import cc.polyfrost.oneconfig.libs.eventbus.invokers.LMFInvoker;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.HashSet;
@@ -43,6 +45,7 @@ public final class EventManager {
      * The instance of the {@link EventManager}.
      */
     public static final EventManager INSTANCE = new EventManager();
+    private static final Logger LOGGER = LogManager.getLogger("OneConfig/EventManager");
     private final EventBus eventBus = new EventBus(new LMFInvoker(), new OneConfigExceptionHandler());
     private final Set<Object> listeners = new HashSet<>();
 
@@ -64,6 +67,8 @@ public final class EventManager {
     public void register(Object object) {
         if (listeners.add(object)) {
             eventBus.register(object);
+        } else {
+            LOGGER.warn("Attempted to register an already registered listener: " + object);
         }
     }
 


### PR DESCRIPTION
## Description
Adds a guard clause to `EventManager#register` to prevent duplicate registration.

This was suggested on discord by `godofthegoths#5017`, please create an issue next time.

## Checklist
- [x] I made a clear description of what was changed
- [x] I stated why these changes were necessary
- [x] I updated documentation or said what needs to be updated
- [x] I made sure these changes are backwards compatible
- [x] This pull request is for one feature/bug fix
