### PR TITLE
use `RenderEvent` instead of `HudRenderEvent`

### DIFF
--- a/src/main/java/cc/polyfrost/oneconfig/gui/OneConfigGui.java
+++ b/src/main/java/cc/polyfrost/oneconfig/gui/OneConfigGui.java
@@ -27,10 +27,11 @@
 package cc.polyfrost.oneconfig.gui;
 
 import cc.polyfrost.oneconfig.config.core.OneColor;
-import cc.polyfrost.oneconfig.events.EventManager;
-import cc.polyfrost.oneconfig.events.event.HudRenderEvent;
 import cc.polyfrost.oneconfig.config.elements.BasicOption;
 import cc.polyfrost.oneconfig.config.elements.OptionSubcategory;
+import cc.polyfrost.oneconfig.events.EventManager;
+import cc.polyfrost.oneconfig.events.event.RenderEvent;
+import cc.polyfrost.oneconfig.events.event.Stage;
 import cc.polyfrost.oneconfig.gui.animations.Animation;
 import cc.polyfrost.oneconfig.gui.animations.DummyAnimation;
 import cc.polyfrost.oneconfig.gui.animations.EaseInBack;
@@ -415,8 +416,8 @@ public class OneConfigGui extends OneUIScreen {
     }
 
     @Subscribe
-    public void onRenderHUD(HudRenderEvent event) {
-        if (!shouldDisplayHud) return;
+    public void onRenderHUD(RenderEvent event) {
+        if (!shouldDisplayHud || event.stage == Stage.START) return;
         if (Platform.getGuiPlatform().getCurrentScreen() == this) return;
 
         NanoVGHelper.INSTANCE.setupAndDraw(vg -> draw(vg, event.deltaTicks, null));

--- a/src/main/java/cc/polyfrost/oneconfig/utils/Notifications.java
+++ b/src/main/java/cc/polyfrost/oneconfig/utils/Notifications.java
@@ -26,7 +26,6 @@
 
 package cc.polyfrost.oneconfig.utils;
 
-import cc.polyfrost.oneconfig.events.event.HudRenderEvent;
 import cc.polyfrost.oneconfig.events.event.RenderEvent;
 import cc.polyfrost.oneconfig.events.event.Stage;
 import cc.polyfrost.oneconfig.gui.OneConfigGui;
@@ -225,7 +224,11 @@ public final class Notifications {
     private float deltaTime = 0;
 
     @Subscribe
-    private void onHudRender(HudRenderEvent event) {
+    private void onRenderEvent(RenderEvent event) {
+        if (event.stage == Stage.START) {
+            deltaTime += GuiUtils.getDeltaTime(); // add up deltatime since we might not render every frame because of hud caching
+            return;
+        }
         if (notifications.size() == 0) return;
         NanoVGHelper.INSTANCE.setupAndDraw((vg) -> {
             float desiredPosition = -16f;
@@ -241,12 +244,5 @@ public final class Notifications {
             notifications.entrySet().removeIf(entry -> entry.getKey().isFinished());
         });
         deltaTime = 0;
-    }
-
-    @Subscribe
-    private void onRenderEvent(RenderEvent event) {
-        if (event.stage == Stage.START) {
-            deltaTime += GuiUtils.getDeltaTime(); // add up deltatime since we might not render every frame because of hud caching
-        }
     }
 }


### PR DESCRIPTION
This is to bypass HUDCaching

## Description
<!-- Describe your changes in detail -->

## Related Issue(s)
<!-- List the issue(s) this PR solves -->

## Checklist
- [x] I made a clear description of what was changed
- [x] I stated why these changes were necessary
- [x] I updated documentation or said what needs to be updated
- [x] I made sure these changes are backwards compatible
- [x] This pull request is for one feature/bug fix
