### PR TITLE
new: `preload` method

### DIFF
--- a/api/OneConfig.api
+++ b/api/OneConfig.api
@@ -24,7 +24,7 @@ public class cc/polyfrost/oneconfig/config/Config {
 	public fun initialize ()V
 	public fun load ()V
 	public fun openGui ()V
-	public fun preload ()V
+	public final fun preload ()V
 	public fun reInitialize ()V
 	public static fun register (Lcc/polyfrost/oneconfig/config/data/Mod;)Lcc/polyfrost/oneconfig/config/data/Mod;
 	protected final fun registerKeyBind (Lcc/polyfrost/oneconfig/config/core/OneKeyBind;Ljava/lang/Runnable;)V

--- a/api/OneConfig.api
+++ b/api/OneConfig.api
@@ -24,6 +24,7 @@ public class cc/polyfrost/oneconfig/config/Config {
 	public fun initialize ()V
 	public fun load ()V
 	public fun openGui ()V
+	public fun preload ()V
 	public fun reInitialize ()V
 	public static fun register (Lcc/polyfrost/oneconfig/config/data/Mod;)Lcc/polyfrost/oneconfig/config/data/Mod;
 	protected final fun registerKeyBind (Lcc/polyfrost/oneconfig/config/core/OneKeyBind;Ljava/lang/Runnable;)V

--- a/src/main/java/cc/polyfrost/oneconfig/config/Config.java
+++ b/src/main/java/cc/polyfrost/oneconfig/config/Config.java
@@ -499,7 +499,7 @@ public class Config {
      * }
      * }</pre>
      */
-    public void preload() {
+    public final void preload() {
 
     }
 }

--- a/src/main/java/cc/polyfrost/oneconfig/config/Config.java
+++ b/src/main/java/cc/polyfrost/oneconfig/config/Config.java
@@ -472,4 +472,34 @@ public class Config {
         ConfigCore.sortMods();
         return null;
     }
+
+    /**
+     * Literally does nothing.
+     * <p>
+     *     As configs HAVE to be initialized before your mod loader's post-init, instances need to be created before that.
+     *     Hence, this method exists so config instances which are located in the actual class instead of the main mod class can be created.
+     * </p>
+     * For example:
+     * <pre>{@code
+     * public class MyConfig {
+     *     // The INSTANCE class is located here, and initialize is called in the constructor.
+     *     // This means that if we do not call preload, the config will not be initialized in time.
+     *     public static final MyConfig INSTANCE = new MyConfig();
+     *
+     *     public MyConfig() {
+     *         super(whatever);
+     *         initialize();
+     *     }
+     * }
+     *
+     * public class MyMod {
+     *     public void initialize() {
+     *         MyConfig.INSTANCE.preload(); // This makes sure the config is initialized before the mod loader's post-init.
+     *     }
+     * }
+     * }</pre>
+     */
+    public void preload() {
+
+    }
 }


### PR DESCRIPTION
## Description
The `preload` method's purpose is to call the static initializer of the config class. As explained in the java-doc:

```
As configs HAVE to be initialized before your mod loader's post-init, instances need to be created before that.
Hence, this method exists so config instances which are located in the actual class instead of the main mod class can be created.
```

## Related Issue(s)
<!-- List the issue(s) this PR solves -->

## Checklist
- [x] I made a clear description of what was changed
- [x] I stated why these changes were necessary
- [x] I updated documentation or said what needs to be updated
- [x] I made sure these changes are backwards compatible
- [x] This pull request is for one feature/bug fix
