### PR TITLE
Fix slider animations being dependent on framerate

### DIFF
--- a/src/main/java/cc/polyfrost/oneconfig/gui/elements/config/ConfigSlider.java
+++ b/src/main/java/cc/polyfrost/oneconfig/gui/elements/config/ConfigSlider.java
@@ -66,6 +66,8 @@ public class ConfigSlider extends BasicOption implements IFocusable {
     private Animation stepsAnimation;
     private Animation targetAnimation;
     private Animation stepSlideAnimation;
+    private float animationStart;
+    private float lastSliderTarget = 1;
     private boolean animReset;
     private float lastX = -1;
 
@@ -82,7 +84,7 @@ public class ConfigSlider extends BasicOption implements IFocusable {
         this.inputField = new NumberInputField(84, 32, 0, min, max, step == 0 ? 1 : step);
         this.stepsAnimation = new DummyAnimation(0);
         this.targetAnimation = new DummyAnimation(0);
-        this.stepSlideAnimation = new DummyAnimation(-1);
+        this.stepSlideAnimation = new DummyAnimation(1);
     }
 
     public static ConfigSlider create(Field field, Object parent) {
@@ -159,14 +161,14 @@ public class ConfigSlider extends BasicOption implements IFocusable {
         }
 
         // Animate sliding
-        if (stepSlideAnimation.get() == -1 || lastX != x) {
-            stepSlideAnimation = new DummyAnimation(xCoordinate);
-        } else {
-            stepSlideAnimation = new EaseInOutCubic((int) Preferences.trackerResponseDuration, stepSlideAnimation.get(), xCoordinate, false);
+        if (stepSlideAnimation.isFinished() && lastSliderTarget != -1 && lastSliderTarget != xCoordinate && (!dragging || startedDragging || step > 0) && lastX == x) {
+            animationStart = lastSliderTarget;
+            stepSlideAnimation = new EaseInOutCubic((int) Preferences.trackerResponseDuration, 0f, 1f, false);
         }
-        xCoordinate = (int) stepSlideAnimation.get();
-
+        float progress = stepSlideAnimation.get();
+        lastSliderTarget = xCoordinate;
         lastX = x;
+        xCoordinate = (int) (xCoordinate * progress + animationStart * (1 - progress));
 
         // Ease-out the radius when the steps are in view
         float radius = 4;


### PR DESCRIPTION
## Description
- Made the slider animation (where sliders animates to new position) not dependent on framerate

Also for the love of god please no one ever use animations recursively like this again

## Related Issue(s)
<!-- List the issue(s) this PR solves -->

## Checklist
- [X] I made a clear description of what was changed
- [X] I stated why these changes were necessary
- [X] I updated documentation or said what needs to be updated
- [X] I made sure these changes are backwards compatible
- [X] This pull request is for one feature/bug fix
