### PR TITLE
update github actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,17 +21,17 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
       - name: Set up JDK 17
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v4
         with:
           java-version: 17
           distribution: temurin
 
-      - uses: actions/cache@v2
+      - uses: actions/cache@v4
         with:
           path: |
             ~/.gradle/caches
@@ -49,7 +49,7 @@ jobs:
         run: ./gradlew build --no-daemon
 
       - name: Upload Build Artifacts
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: oneconfig-artifacts
           path: versions/**/build/libs/

--- a/.github/workflows/gradle-validation.yml
+++ b/.github/workflows/gradle-validation.yml
@@ -6,6 +6,6 @@ jobs:
     name: "Validation"
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: gradle/wrapper-validation-action@v1
+      - uses: actions/checkout@v4
+      - uses: gradle/wrapper-validation-action@v2
       

--- a/.github/workflows/release-snapshots.yml
+++ b/.github/workflows/release-snapshots.yml
@@ -19,17 +19,17 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
       - name: Set up JDK 17
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v4
         with:
           java-version: 17
           distribution: temurin
 
-      - uses: actions/cache@v2
+      - uses: actions/cache@v4
         with:
           path: |
             ~/.gradle/caches
@@ -51,7 +51,7 @@ jobs:
         run: ./gradlew publishAllPublicationsToSnapshotsRepository -Pmod_minor_version=${{ steps.version.outputs.VERSION_NUMBER }} -PsnapshotsUsername=${{ secrets.MAVEN_NAME }} -PsnapshotsPassword=${{ secrets.MAVEN_TOKEN }} -DBUILDING_CI=true --no-daemon
 
       - name: Upload Build Artifacts
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: oneconfig-artifacts
           path: versions/**/build/libs/

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,17 +19,17 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
       - name: Set up JDK 17
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v4
         with:
           java-version: 17
           distribution: temurin
 
-      - uses: actions/cache@v2
+      - uses: actions/cache@v4
         with:
           path: |
             ~/.gradle/caches
@@ -51,7 +51,7 @@ jobs:
         run: ./gradlew publishAllPublicationsToReleasesRepository -Pmod_minor_version=${{ steps.version.outputs.VERSION_NUMBER }} -PreleasesUsername=${{ secrets.MAVEN_NAME }} -PreleasesPassword=${{ secrets.MAVEN_TOKEN }} -DBUILDING_CI=true --no-daemon
 
       - name: Upload Build Artifacts
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: oneconfig-artifacts
           path: versions/**/build/libs/


### PR DESCRIPTION
## Description
surely just updating github actions won't break anything

## Related Issue(s)
> The following actions uses node12 which is deprecated and will be forced to run on node16: actions/checkout@v2, actions/setup-java@v2, actions/cache@v2, actions/upload-artifact@v2. For more info: https://github.blog/changelog/2023-06-13-github-actions-all-actions-will-run-on-node16-instead-of-node12-by-default/

\- https://github.com/Polyfrost/OneConfig/actions/runs/7612697608

## Checklist
- [x] I made a clear description of what was changed
- [x] I stated why these changes were necessary
- [ ] I updated documentation or said what needs to be updated
- [ ] I made sure these changes are backwards compatible
- [x] This pull request is for one feature/bug fix
