### PR TITLE
V1 Patches for Legacy V0 support

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 mod_name = OneConfig
-mod_id = oneconfig
+mod_id = oneconfigv0
 mod_major_version = 0.2.2-alpha
 mod_minor_version = -LOCAL
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -16,7 +16,7 @@ deencapsulation = "42b829f373"
 caffeine = "2.9.3"
 mixin = "0.7.11-SNAPSHOT"
 
-lwjgl = "1.0.0-alpha26"
+lwjgl = "1.0.0-alpha27"
 fabric-asm = "v2.3"
 
 [libraries]

--- a/src/main/java/cc/polyfrost/oneconfig/internal/renderer/FontHelperImpl.java
+++ b/src/main/java/cc/polyfrost/oneconfig/internal/renderer/FontHelperImpl.java
@@ -69,7 +69,7 @@ public class FontHelperImpl implements FontHelper {
         int loaded = -1;
         try {
             ByteBuffer buffer = IOUtils.resourceToByteBuffer(font.getFileName(), font.getClass());
-            loaded = nvgCreateFontMem(vg, font.getName(), buffer, 0);
+            loaded = nvgCreateFontMem(vg, font.getName(), buffer, false);
             font.setBuffer(buffer);
         } catch (IOException e) {
             e.printStackTrace();

--- a/versions/build.gradle.kts
+++ b/versions/build.gradle.kts
@@ -316,12 +316,12 @@ tasks {
                             "ModSide" to "CLIENT",
                             "ForceLoadAsMod" to true,
                             "TweakOrder" to "0",
-                            "MixinConfigs" to "mixins.oneconfig.json",
+                            "MixinConfigs" to "mixins.oneconfigv0.json",
                             "TweakClass" to "cc.polyfrost.oneconfig.internal.plugin.asm.OneConfigTweaker"
                         )
                     } else {
                         mapOf(
-                            "MixinConfigs" to "mixins.oneconfig.json",
+                            "MixinConfigs" to "mixins.oneconfigv0.json",
                             "Specification-Title" to modId,
                             "Specification-Vendor" to modId,
                             "Specification-Version" to "1", // We are version 1 of ourselves, whatever the hell that means

--- a/versions/build.gradle.kts
+++ b/versions/build.gradle.kts
@@ -123,14 +123,6 @@ val shadeOnly: Configuration by configurations.creating
 
 val shadeNoJar: Configuration by configurations.creating
 
-private enum class RepackedVersion(val string: String) {
-    LEGACY("legacy"), PRE119NOARM("pre-1.19-noarm"), PRE119ARM("pre-1.19-arm"), POST119("post-1.19");
-
-    override fun toString(): String {
-        return string
-    }
-}
-
 dependencies {
     compileOnly(libs.vigilance) {
         isTransitive = false
@@ -164,20 +156,12 @@ dependencies {
         }
     }
 
-    val repackedVersions = when (platform.mcVersion) {
-        in 10809..11202 -> listOf(RepackedVersion.LEGACY)
-        in 11203..11802 -> listOf(RepackedVersion.PRE119NOARM, RepackedVersion.PRE119ARM)
-        else -> listOf(RepackedVersion.POST119)
-    }
-
-    repackedVersions.forEachIndexed { index, version ->
-        val configuration = configurations.create("tempLwjglConfiguration$index")
-
-        compileOnly(configuration("cc.polyfrost:lwjgl-$version:${libs.versions.lwjgl.get()}"){
-            isTransitive = false
-        })
-        shadeNoPom(implementationNoPom(prebundle(configuration, "lwjgl-$version.jar"))!!)
-    }
+    val configuration = configurations.create("tempLwjglConfiguration")
+    val version = if (platform.mcVersion < 11300) "legacy" else "modern"
+    compileOnly(configuration("cc.polyfrost:lwjgl-$version:${libs.versions.lwjgl.get()}") {
+        isTransitive = false
+    })
+    shadeNoPom(implementationNoPom(prebundle(configuration, "lwjgl-$version.jar"))!!)
 
     modRuntimeOnly("me.djtheredstoner:DevAuth-" +
             (if (platform.isForge) { if (platform.isLegacyForge) "forge-legacy" else "forge-latest" } else "fabric")

--- a/versions/src/main/resources/fabric.mod.json
+++ b/versions/src/main/resources/fabric.mod.json
@@ -15,7 +15,7 @@
   "license": "LGPL-3.0",
   "environment": "client",
   "mixins": [
-    "mixins.oneconfig.json"
+    "mixins.oneconfigv0.json"
   ],
   "entrypoints": {
     "preLaunch": [

--- a/versions/src/main/resources/mixins.oneconfigv0.json
+++ b/versions/src/main/resources/mixins.oneconfigv0.json
@@ -2,7 +2,7 @@
   "compatibilityLevel": "JAVA_8",
   "minVersion": "0.7",
   "package": "cc.polyfrost.oneconfig.internal.mixin",
-  "refmap": "mixins.oneconfig.refmap.json",
+  "refmap": "mixins.oneconfigv0.refmap.json",
   "plugin": "cc.polyfrost.oneconfig.internal.plugin.OneConfigMixinPlugin",
   "injectors": {
     "maxShiftBy": 5


### PR DESCRIPTION
## Description
- set the modid from `oneconfig` to `oneconfigv0`
- bump lwjgl from 3.3.1 to 3.3.3 (updated and archived lwjgl-repacked)

## Related Issue(s)
- running the mod alongside v1

## Checklist
- [x] I made a clear description of what was changed
- [x] I stated why these changes were necessary
- [x] I updated documentation or said what needs to be updated
- [x] I made sure these changes are backwards compatible
- [x] This pull request is for one feature/bug fix
