### PR TITLE
Make canToggle transient

### DIFF
--- a/src/main/java/cc/polyfrost/oneconfig/config/Config.java
+++ b/src/main/java/cc/polyfrost/oneconfig/config/Config.java
@@ -89,7 +89,7 @@ public class Config {
             .create();
     public final transient Mod mod;
     public boolean enabled;
-    public final boolean canToggle;
+    public final transient boolean canToggle;
 
     private final transient Logger logger;
 


### PR DESCRIPTION
## Description

Property "canToggle" is currently stored in config file.
If a mod developer changes this property via a constructor, all users need to manually regenerate config files for this change to take effect.
This PR fixes this issue, by making canToggle property transient.

<!-- Describe your changes in detail -->

## Related Issue(s)

None

<!-- List the issue(s) this PR solves -->

## Checklist

- [x] I made a clear description of what was changed
- [x] I stated why these changes were necessary
- [x] I updated documentation or said what needs to be updated
- [x] I made sure these changes are backwards compatible
- [x] This pull request is for one feature/bug fix
