### PR TITLE
Add `ADAPTER` constant to KotlinLanguageAdapter

### DIFF
--- a/minecraft/src/main/java/org/polyfrost/oneconfig/utils/v1/forge/KotlinLanguageAdapter.java
+++ b/minecraft/src/main/java/org/polyfrost/oneconfig/utils/v1/forge/KotlinLanguageAdapter.java
@@ -44,6 +44,8 @@ import java.lang.reflect.Method;
  */
 public class KotlinLanguageAdapter implements ILanguageAdapter {
 
+    public static final String ADAPTER = "org.polyfrost.oneconfig.utils.v1.forge.KotlinLanguageAdapter";
+
     private static Object getObjectInstance(Class<?> objectClass) {
         try {
             Object instance = kotlin.jvm.JvmClassMappingKt.getKotlinClass(objectClass).getObjectInstance();


### PR DESCRIPTION
## Description

<!-- Describe your changes in detail -->

Adds a constant to KotlinLanguageAdapter that'll allow you to easily reference the adapter in your Mod annotation.

```java
// BEFORE
@Mod(
    modid = MyMod.ID,
    modLanguageAdapter = "org.polyfrost.oneconfig.utils.v1.forge.KotlinLanguageAdapter"
)

// AFTER
@Mod(
    modid = MyMod.ID,
    modLanguageAdapter = KotlinLanguageAdapter.ADAPTER
)
```

This allows mod devs to avoid needing to remember the class name. It also reduces the chance of typos

## Related Issue(s)

<!-- List the issue(s) this PR solves -->
N/A

## Checklist

- [x] I made a clear description of what was changed
- [x] I stated why these changes were necessary
- [ ] I updated documentation or said what needs to be updated
- [x] I made sure these changes are backwards compatible
- [x] This pull request is for one feature/bug fix
