### PR TITLE
Proposal to fix #597

### DIFF
--- a/modules/config-impl/api/config-impl.api
+++ b/modules/config-impl/api/config-impl.api
@@ -25,7 +25,6 @@ public abstract class org/polyfrost/oneconfig/api/config/v1/Config {
 	protected fun initialize (Z)V
 	protected fun loadFrom (Ljava/lang/String;)V
 	protected fun loadFrom (Ljava/nio/file/Path;)V
-	protected fun loadFromAndDelete (Ljava/nio/file/Path;)V
 	protected fun makeTree ()Lorg/polyfrost/oneconfig/api/config/v1/Tree;
 	public fun preload ()V
 	protected fun restoreDefaults ()V

--- a/modules/config-impl/config-to-migrate-for-test/test_migration_mod.json
+++ b/modules/config-impl/config-to-migrate-for-test/test_migration_mod.json
@@ -1,0 +1,4 @@
+{
+  "chicken": false,
+  "cow5": true
+}

--- a/modules/config-impl/src/main/java/org/polyfrost/oneconfig/api/config/v1/Config.java
+++ b/modules/config-impl/src/main/java/org/polyfrost/oneconfig/api/config/v1/Config.java
@@ -200,7 +200,7 @@ public abstract class Config {
         if (tree == null) initialize(false);
         Tree in = ConfigManager.active().get(id);
         if (in == null) return;
-        tree.overwrite(in, false);
+        tree.overwrite(in, false, true);
     }
 
     protected void loadFrom(Path p) {
@@ -212,18 +212,8 @@ public abstract class Config {
             return;
         }
         if (in == null) return;
-        tree.overwrite(in, false);
+        tree.overwrite(in, false, true);
     }
-
-    protected void loadFromAndDelete(Path p) {
-        try {
-            loadFrom(p);
-            Files.deleteIfExists(p);
-        } catch (Exception e) {
-            ConfigManager.LOGGER.error("An unknown error occurred", e);
-        }
-    }
-
 
     protected Property<?> getProperty(String option) {
         if (tree == null) initialize(false);

--- a/modules/config-impl/src/main/java/org/polyfrost/oneconfig/api/config/v1/Config.java
+++ b/modules/config-impl/src/main/java/org/polyfrost/oneconfig/api/config/v1/Config.java
@@ -33,7 +33,6 @@ import org.jetbrains.annotations.Nullable;
 import org.polyfrost.oneconfig.api.config.v1.annotations.Include;
 import org.polyfrost.polyui.data.PolyImage;
 
-import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -200,7 +199,7 @@ public abstract class Config {
         if (tree == null) initialize(false);
         Tree in = ConfigManager.active().get(id);
         if (in == null) return;
-        tree.overwrite(in, false, true);
+        tree.overwrite(in, false, true, tree);
     }
 
     protected void loadFrom(Path p) {
@@ -212,7 +211,7 @@ public abstract class Config {
             return;
         }
         if (in == null) return;
-        tree.overwrite(in, false, true);
+        tree.overwrite(in, false, true, tree);
     }
 
     protected Property<?> getProperty(String option) {

--- a/modules/config-impl/src/test/java/org/polyfrost/oneconfig/api/config/v1/MainTest.java
+++ b/modules/config-impl/src/test/java/org/polyfrost/oneconfig/api/config/v1/MainTest.java
@@ -26,17 +26,28 @@
 
 package org.polyfrost.oneconfig.api.config.v1;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
+import java.io.File;
+
+import static org.junit.jupiter.api.Assertions.*;
 
 public class MainTest {
     @org.junit.jupiter.api.Test
     void test() {
+        File configFile = new File("config/test_mod.json");
+        assertTrue(!configFile.exists() || configFile.delete());
         TestConfig config = new TestConfig();
         config.initialize(true);
         Tree t = config.tree;
         assertEquals(t, ConfigManager.active().get(t.getID()));
         assertNotNull(t.get("chicken").getMetadata("visualizer"));
+        assertNull(t.get("reserved:overwritten"));
+        System.err.println(t);
+        assertTrue(TestConfig.chicken);
+        assertFalse(TestConfig.cow5);
+        config.loadFrom(new File(new File(new File(".").getParentFile(), "config-to-migrate-for-test"), "test_migration_mod.json").toPath());
+        assertNotNull(t.get("reserved:overwritten"));
+        assertFalse(TestConfig.chicken);
+        assertTrue(TestConfig.cow5);
         System.err.println(t);
     }
 }

--- a/modules/config/api/config.api
+++ b/modules/config/api/config.api
@@ -15,7 +15,7 @@ public abstract class org/polyfrost/oneconfig/api/config/v1/Node {
 	public final fun hasMetadata ()Z
 	public final fun hashCode ()I
 	public fun overwrite (Lorg/polyfrost/oneconfig/api/config/v1/Node;Z)V
-	public abstract fun overwrite (Lorg/polyfrost/oneconfig/api/config/v1/Node;ZZ)V
+	public abstract fun overwrite (Lorg/polyfrost/oneconfig/api/config/v1/Node;ZZLorg/polyfrost/oneconfig/api/config/v1/Tree;)V
 	public final fun removeMetadata (Ljava/lang/String;)Z
 	public fun setID (Ljava/lang/String;)V
 	public fun setTitle (Ljava/lang/String;)V
@@ -71,7 +71,7 @@ public abstract class org/polyfrost/oneconfig/api/config/v1/Property : org/polyf
 	public final fun isArray ()Z
 	public final fun isPrimitive ()Z
 	public fun onDisplayChange (Ljava/util/function/Consumer;)V
-	public fun overwrite (Lorg/polyfrost/oneconfig/api/config/v1/Node;ZZ)V
+	public fun overwrite (Lorg/polyfrost/oneconfig/api/config/v1/Node;ZZLorg/polyfrost/oneconfig/api/config/v1/Tree;)V
 	public static fun recast (Lorg/polyfrost/oneconfig/api/config/v1/Property;)Lorg/polyfrost/oneconfig/api/config/v1/Property;
 	public fun revaluateDisplay ()V
 	public final fun set (Ljava/lang/Object;)V
@@ -113,8 +113,8 @@ public class org/polyfrost/oneconfig/api/config/v1/Tree : org/polyfrost/oneconfi
 	public fun getProp ([Ljava/lang/String;)Lorg/polyfrost/oneconfig/api/config/v1/Property;
 	public fun onAll (Ljava/util/function/BiConsumer;)V
 	public fun onAllProps (Ljava/util/function/BiConsumer;)V
-	public fun overwrite (Lorg/polyfrost/oneconfig/api/config/v1/Node;ZZ)V
-	public fun overwrite (Lorg/polyfrost/oneconfig/api/config/v1/Tree;Ljava/util/function/Function;ZZ)V
+	public fun overwrite (Lorg/polyfrost/oneconfig/api/config/v1/Node;ZZLorg/polyfrost/oneconfig/api/config/v1/Tree;)V
+	public fun overwrite (Lorg/polyfrost/oneconfig/api/config/v1/Tree;Ljava/util/function/Function;ZZLorg/polyfrost/oneconfig/api/config/v1/Tree;)V
 	public fun put (Lorg/polyfrost/oneconfig/api/config/v1/Node;)Lorg/polyfrost/oneconfig/api/config/v1/Tree;
 	public fun put ([Lorg/polyfrost/oneconfig/api/config/v1/Node;)Lorg/polyfrost/oneconfig/api/config/v1/Tree;
 	public fun set (Ljava/lang/String;Lorg/polyfrost/oneconfig/api/config/v1/Node;)Lorg/polyfrost/oneconfig/api/config/v1/Tree;

--- a/modules/config/api/config.api
+++ b/modules/config/api/config.api
@@ -14,7 +14,8 @@ public abstract class org/polyfrost/oneconfig/api/config/v1/Node {
 	public fun getTitle ()Ljava/lang/String;
 	public final fun hasMetadata ()Z
 	public final fun hashCode ()I
-	public abstract fun overwrite (Lorg/polyfrost/oneconfig/api/config/v1/Node;Z)V
+	public fun overwrite (Lorg/polyfrost/oneconfig/api/config/v1/Node;Z)V
+	public abstract fun overwrite (Lorg/polyfrost/oneconfig/api/config/v1/Node;ZZ)V
 	public final fun removeMetadata (Ljava/lang/String;)Z
 	public fun setID (Ljava/lang/String;)V
 	public fun setTitle (Ljava/lang/String;)V
@@ -70,7 +71,7 @@ public abstract class org/polyfrost/oneconfig/api/config/v1/Property : org/polyf
 	public final fun isArray ()Z
 	public final fun isPrimitive ()Z
 	public fun onDisplayChange (Ljava/util/function/Consumer;)V
-	public fun overwrite (Lorg/polyfrost/oneconfig/api/config/v1/Node;Z)V
+	public fun overwrite (Lorg/polyfrost/oneconfig/api/config/v1/Node;ZZ)V
 	public static fun recast (Lorg/polyfrost/oneconfig/api/config/v1/Property;)Lorg/polyfrost/oneconfig/api/config/v1/Property;
 	public fun revaluateDisplay ()V
 	public final fun set (Ljava/lang/Object;)V
@@ -112,8 +113,8 @@ public class org/polyfrost/oneconfig/api/config/v1/Tree : org/polyfrost/oneconfi
 	public fun getProp ([Ljava/lang/String;)Lorg/polyfrost/oneconfig/api/config/v1/Property;
 	public fun onAll (Ljava/util/function/BiConsumer;)V
 	public fun onAllProps (Ljava/util/function/BiConsumer;)V
-	public fun overwrite (Lorg/polyfrost/oneconfig/api/config/v1/Node;Z)V
-	public fun overwrite (Lorg/polyfrost/oneconfig/api/config/v1/Tree;Ljava/util/function/Function;Z)V
+	public fun overwrite (Lorg/polyfrost/oneconfig/api/config/v1/Node;ZZ)V
+	public fun overwrite (Lorg/polyfrost/oneconfig/api/config/v1/Tree;Ljava/util/function/Function;ZZ)V
 	public fun put (Lorg/polyfrost/oneconfig/api/config/v1/Node;)Lorg/polyfrost/oneconfig/api/config/v1/Tree;
 	public fun put ([Lorg/polyfrost/oneconfig/api/config/v1/Node;)Lorg/polyfrost/oneconfig/api/config/v1/Tree;
 	public fun set (Ljava/lang/String;Lorg/polyfrost/oneconfig/api/config/v1/Node;)Lorg/polyfrost/oneconfig/api/config/v1/Tree;

--- a/modules/config/src/main/java/org/polyfrost/oneconfig/api/config/v1/Node.java
+++ b/modules/config/src/main/java/org/polyfrost/oneconfig/api/config/v1/Node.java
@@ -187,6 +187,10 @@ public abstract class Node {
         return metadata != null;
     }
 
+    public void overwrite(Node with, boolean preserveMissingOptions) {
+        overwrite(with, preserveMissingOptions, false);
+    }
+
     /**
      * Overwrite all data in this node with the data from another node.
      * <br><ul>
@@ -198,7 +202,7 @@ public abstract class Node {
      * @param with the node to overwrite this with
      * @param preserveMissingOptions if true, any properties that are missing in THIS tree that are present in the input tree, will be added to this tree.
      */
-    public abstract void overwrite(Node with, boolean preserveMissingOptions);
+    public abstract void overwrite(Node with, boolean preserveMissingOptions, boolean markOverwritten);
 
     @SuppressWarnings("BooleanMethodIsAlwaysInverted")
     @VisibleForTesting

--- a/modules/config/src/main/java/org/polyfrost/oneconfig/api/config/v1/Node.java
+++ b/modules/config/src/main/java/org/polyfrost/oneconfig/api/config/v1/Node.java
@@ -188,7 +188,7 @@ public abstract class Node {
     }
 
     public void overwrite(Node with, boolean preserveMissingOptions) {
-        overwrite(with, preserveMissingOptions, false);
+        overwrite(with, preserveMissingOptions, false, null);
     }
 
     /**
@@ -201,8 +201,10 @@ public abstract class Node {
      *
      * @param with the node to overwrite this with
      * @param preserveMissingOptions if true, any properties that are missing in THIS tree that are present in the input tree, will be added to this tree.
+     * @param skipOverwritten **DEPENDS ON PARAM "ROOT" BEING NOT NULL** - skips being overwritten if a child node has already been marked as overwritten in the root tree.
+     * @param root The root tree used to mark overwritten nodes for skipOverwritten. May be null if skipOverwritten is false.
      */
-    public abstract void overwrite(Node with, boolean preserveMissingOptions, boolean markOverwritten);
+    public abstract void overwrite(Node with, boolean preserveMissingOptions, boolean skipOverwritten, @Nullable Tree root);
 
     @SuppressWarnings("BooleanMethodIsAlwaysInverted")
     @VisibleForTesting

--- a/modules/config/src/main/java/org/polyfrost/oneconfig/api/config/v1/Property.java
+++ b/modules/config/src/main/java/org/polyfrost/oneconfig/api/config/v1/Property.java
@@ -181,18 +181,28 @@ public abstract class Property<T> extends Node implements Serializable {
 
     @Override
     @SuppressWarnings({"unchecked", "rawtypes"})
-    public void overwrite(Node with, boolean preserveMissingOptions, boolean markOverwritten) {
+    public void overwrite(Node with, boolean preserveMissingOptions, boolean skipOverwritten, @Nullable Tree root) {
         if (!(with instanceof Property)) throw new IllegalArgumentException("Cannot overwrite a property with a non-property");
         if (!Objects.equals(this.getID(), with.getID())) throw new IllegalArgumentException("ID should be the same for overwrite");
-        if (markOverwritten && Objects.equals(getMetadata("overwritten"), true)) return;
+        if (skipOverwritten && root == null) {
+            throw new IllegalArgumentException("Cannot mark overwritten without a root tree!");
+        }
+        Node overwritten = null;
+        if (root != null) {
+            overwritten = root.get("reserved:overwritten");
+        }
+        if (skipOverwritten && overwritten instanceof Tree && !Objects.equals(((Tree) overwritten).get(with.getID()), null)) {
+            return;
+        }
         Property<?> that = (Property<?>) with;
         this.addMetadata(that.getMetadata());
         Object in = that.get();
         if (in != null) this.setAsReferential(in);
         if (that.conditions != null) this.addDisplayCondition(that.conditions);
         if (that.callbacks != null) addCallback((Collection) that.callbacks);
-        if (markOverwritten) {
-            addMetadata("overwritten", true);
+        if (root != null) {
+            overwritten = root.getOrPutChild("reserved:overwritten");
+            ((Tree) overwritten).put(new Tree(that.getID(), null, null, null));
         }
     }
 

--- a/modules/config/src/main/java/org/polyfrost/oneconfig/api/config/v1/Property.java
+++ b/modules/config/src/main/java/org/polyfrost/oneconfig/api/config/v1/Property.java
@@ -181,15 +181,19 @@ public abstract class Property<T> extends Node implements Serializable {
 
     @Override
     @SuppressWarnings({"unchecked", "rawtypes"})
-    public void overwrite(Node with, boolean preserveMissingOptions) {
+    public void overwrite(Node with, boolean preserveMissingOptions, boolean markOverwritten) {
         if (!(with instanceof Property)) throw new IllegalArgumentException("Cannot overwrite a property with a non-property");
         if (!Objects.equals(this.getID(), with.getID())) throw new IllegalArgumentException("ID should be the same for overwrite");
+        if (markOverwritten && Objects.equals(getMetadata("overwritten"), true)) return;
         Property<?> that = (Property<?>) with;
         this.addMetadata(that.getMetadata());
         Object in = that.get();
         if (in != null) this.setAsReferential(in);
         if (that.conditions != null) this.addDisplayCondition(that.conditions);
         if (that.callbacks != null) addCallback((Collection) that.callbacks);
+        if (markOverwritten) {
+            addMetadata("overwritten", true);
+        }
     }
 
     /**

--- a/modules/config/src/main/java/org/polyfrost/oneconfig/api/config/v1/Tree.java
+++ b/modules/config/src/main/java/org/polyfrost/oneconfig/api/config/v1/Tree.java
@@ -154,7 +154,7 @@ public class Tree extends Node implements Serializable {
         if (old == n) return this; // yeah, ok.
         if (old != null) {
 //            LOGGER.warn("Replacing existing node with id {}: {} -> {}", n.getID(), old, n);
-            n.overwrite(old, false, false);
+            n.overwrite(old, false);
         }
         theMap.put(n.getID(), n);
         return this;

--- a/modules/config/src/main/java/org/polyfrost/oneconfig/api/config/v1/Tree.java
+++ b/modules/config/src/main/java/org/polyfrost/oneconfig/api/config/v1/Tree.java
@@ -32,6 +32,7 @@ import java.io.Serializable;
 import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.Map;
+import java.util.Objects;
 import java.util.function.BiConsumer;
 import java.util.function.Function;
 import java.util.stream.Collectors;
@@ -68,7 +69,7 @@ public class Tree extends Node implements Serializable {
         }
     }
 
-    private static void _overwrite(Tree self, Tree in, Function<String, String> keyMapper, boolean preserveMissingOptions) {
+    private static void _overwrite(Tree self, Tree in, Function<String, String> keyMapper, boolean preserveMissingOptions, boolean markOverwritten) {
         for (Map.Entry<String, Node> from : in.theMap.entrySet()) {
             String key = keyMapper == null ? from.getKey() : keyMapper.apply(from.getKey());
             Node _this = self.get(key);
@@ -82,15 +83,16 @@ public class Tree extends Node implements Serializable {
                 continue;
             }
             if (_this instanceof Tree) {
-                if (that instanceof Tree) {
+                if (that instanceof Tree && Objects.equals(_this.getMetadata("overwritten"), true)) {
                     // if both are trees, recursively overwrite
-                    _overwrite((Tree) _this, (Tree) that, keyMapper, preserveMissingOptions);
+                    _overwrite((Tree) _this, (Tree) that, keyMapper, preserveMissingOptions, markOverwritten);
                     _this.addMetadata(that.getMetadata());
+                    _this.addMetadata("overwritten", true);
                 }
                 // nop. do not attempt to overwrite a tree with a property
                 else continue;
             }
-            _this.overwrite(that, preserveMissingOptions);
+            _this.overwrite(that, preserveMissingOptions, markOverwritten);
         }
     }
 
@@ -152,7 +154,7 @@ public class Tree extends Node implements Serializable {
         if (old == n) return this; // yeah, ok.
         if (old != null) {
 //            LOGGER.warn("Replacing existing node with id {}: {} -> {}", n.getID(), old, n);
-            n.overwrite(old, false);
+            n.overwrite(old, false, false);
         }
         theMap.put(n.getID(), n);
         return this;
@@ -273,18 +275,18 @@ public class Tree extends Node implements Serializable {
      * @param with      the tree to overwrite with
      * @param keyMapper the key mapper function to use
      */
-    public void overwrite(Tree with, @NotNull Function<String, String> keyMapper, boolean preserveMissingOptions) {
-        _overwrite(this, with, keyMapper, preserveMissingOptions);
+    public void overwrite(Tree with, @NotNull Function<String, String> keyMapper, boolean preserveMissingOptions, boolean markOverwritten) {
+        _overwrite(this, with, keyMapper, preserveMissingOptions, markOverwritten);
     }
 
     @Override
-    public void overwrite(@NotNull Node with, boolean preserveMissingOptions) {
+    public void overwrite(@NotNull Node with, boolean preserveMissingOptions, boolean markOverwritten) {
         if (!(with instanceof Tree)) throw new IllegalArgumentException("Cannot overwrite a tree with a non-tree node!");
         Map<String, String> migrationMap = getMetadata("migrationMap");
         if (migrationMap == null) {
-            _overwrite(this, (Tree) with, null, preserveMissingOptions);
+            _overwrite(this, (Tree) with, null, preserveMissingOptions, markOverwritten);
         } else {
-            _overwrite(this, (Tree) with, migrationMap::get, preserveMissingOptions);
+            _overwrite(this, (Tree) with, migrationMap::get, preserveMissingOptions, markOverwritten);
         }
     }
 

--- a/modules/config/src/main/java/org/polyfrost/oneconfig/api/config/v1/Tree.java
+++ b/modules/config/src/main/java/org/polyfrost/oneconfig/api/config/v1/Tree.java
@@ -69,7 +69,11 @@ public class Tree extends Node implements Serializable {
         }
     }
 
-    private static void _overwrite(Tree self, Tree in, Function<String, String> keyMapper, boolean preserveMissingOptions, boolean markOverwritten) {
+    private static void _overwrite(Tree self, Tree in, Function<String, String> keyMapper, boolean preserveMissingOptions, boolean skipOverwritten, @Nullable Tree root) {
+        Node overwritten = null;
+        if (root != null) {
+            overwritten = root.get("reserved:overwritten");
+        }
         for (Map.Entry<String, Node> from : in.theMap.entrySet()) {
             String key = keyMapper == null ? from.getKey() : keyMapper.apply(from.getKey());
             Node _this = self.get(key);
@@ -83,16 +87,23 @@ public class Tree extends Node implements Serializable {
                 continue;
             }
             if (_this instanceof Tree) {
-                if (that instanceof Tree && Objects.equals(_this.getMetadata("overwritten"), true)) {
+                if (skipOverwritten && overwritten instanceof Tree && !Objects.equals(((Tree) overwritten).get(that.getID()), null)) {
+                    // this node was previously overwritten, skip
+                    continue;
+                }
+                if (that instanceof Tree) {
                     // if both are trees, recursively overwrite
-                    _overwrite((Tree) _this, (Tree) that, keyMapper, preserveMissingOptions, markOverwritten);
+                    _overwrite((Tree) _this, (Tree) that, keyMapper, preserveMissingOptions, skipOverwritten, root);
                     _this.addMetadata(that.getMetadata());
-                    _this.addMetadata("overwritten", true);
+                    if (root != null) {
+                        overwritten = root.getOrPutChild("reserved:overwritten");
+                        ((Tree) overwritten).put(new Tree(that.getID(), null, null, null));
+                    }
                 }
                 // nop. do not attempt to overwrite a tree with a property
                 else continue;
             }
-            _this.overwrite(that, preserveMissingOptions, markOverwritten);
+            _this.overwrite(that, preserveMissingOptions, skipOverwritten, root);
         }
     }
 
@@ -275,18 +286,21 @@ public class Tree extends Node implements Serializable {
      * @param with      the tree to overwrite with
      * @param keyMapper the key mapper function to use
      */
-    public void overwrite(Tree with, @NotNull Function<String, String> keyMapper, boolean preserveMissingOptions, boolean markOverwritten) {
-        _overwrite(this, with, keyMapper, preserveMissingOptions, markOverwritten);
+    public void overwrite(Tree with, @NotNull Function<String, String> keyMapper, boolean preserveMissingOptions, boolean skipOverwritten, @Nullable Tree root) {
+        _overwrite(this, with, keyMapper, preserveMissingOptions, skipOverwritten, root);
     }
 
     @Override
-    public void overwrite(@NotNull Node with, boolean preserveMissingOptions, boolean markOverwritten) {
+    public void overwrite(@NotNull Node with, boolean preserveMissingOptions, boolean skipOverwritten, @Nullable Tree root) {
         if (!(with instanceof Tree)) throw new IllegalArgumentException("Cannot overwrite a tree with a non-tree node!");
+        if (skipOverwritten && root == null) {
+            throw new IllegalArgumentException("Cannot mark overwritten without a root tree!");
+        }
         Map<String, String> migrationMap = getMetadata("migrationMap");
         if (migrationMap == null) {
-            _overwrite(this, (Tree) with, null, preserveMissingOptions, markOverwritten);
+            _overwrite(this, (Tree) with, null, preserveMissingOptions, skipOverwritten, root);
         } else {
-            _overwrite(this, (Tree) with, migrationMap::get, preserveMissingOptions, markOverwritten);
+            _overwrite(this, (Tree) with, migrationMap::get, preserveMissingOptions, skipOverwritten, root);
         }
     }
 

--- a/modules/config/src/main/java/org/polyfrost/oneconfig/api/config/v1/backend/Backend.java
+++ b/modules/config/src/main/java/org/polyfrost/oneconfig/api/config/v1/backend/Backend.java
@@ -35,10 +35,7 @@ import org.jetbrains.annotations.UnmodifiableView;
 import org.polyfrost.oneconfig.api.config.v1.Node;
 import org.polyfrost.oneconfig.api.config.v1.Tree;
 
-import java.util.Collection;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.Map;
+import java.util.*;
 
 /**
  * A backend is a storage system for ConfigTrees.
@@ -114,6 +111,9 @@ public abstract class Backend {
             return false;
         }
         if (t == null) return false;
+        if (t.get("reserved:overwritten") != null) {
+            tree.put(Objects.requireNonNull(t.get("reserved:overwritten")));
+        }
         tree.overwrite(t, false);
 
         putSafe(tree);


### PR DESCRIPTION
In this new version of `loadFrom`, overwritten / migrated options are marked as such via an object in the root tree (config) called `reserved:overwritten`. They are not allowed to be overwritten again after this point. 