### PR TITLE
fix: exclude hidden/test configs from global search results

### DIFF
--- a/modules/internal/src/main/kotlin/org/polyfrost/oneconfig/internal/ui/api/ConfigRegistry.kt
+++ b/modules/internal/src/main/kotlin/org/polyfrost/oneconfig/internal/ui/api/ConfigRegistry.kt
@@ -30,6 +30,13 @@ object ConfigRegistry {
         "libjf-translate-v1",
     )
 
+    private val dedicatedScreenConfigIds = setOf(
+        "oneconfig.json",
+        "themes.json",
+    )
+
+    private val hiddenSearchIds = hiddenModCardIds - dedicatedScreenConfigIds
+
     private val hiddenModCardTitles = setOf(
         "trender",
         "libjf config",
@@ -47,6 +54,9 @@ object ConfigRegistry {
 
     fun shouldShowModCard(config: ConfigData): Boolean =
         config.id.lowercase() !in hiddenModCardIds && config.title.toString().lowercase() !in hiddenModCardTitles
+
+    fun shouldShowInSearch(config: ConfigData): Boolean =
+        config.id.lowercase() !in hiddenSearchIds && config.title.toString().lowercase() !in hiddenModCardTitles
 
     /**
      * Loads all trees from the given [ConfigManager] as [source] entries.

--- a/modules/internal/src/main/kotlin/org/polyfrost/oneconfig/internal/ui/components/Header.kt
+++ b/modules/internal/src/main/kotlin/org/polyfrost/oneconfig/internal/ui/components/Header.kt
@@ -246,6 +246,7 @@ internal fun performSearch(query: String): Map<String, List<SearchResult>> {
     }
 
     for (configData in ConfigRegistry.configs) {
+        if (!ConfigRegistry.shouldShowInSearch(configData)) continue
         val tree = (configData as? TreeConfigData)?.tree ?: continue
         val matchingOptions = mutableListOf<SearchResult>()
         tree.map.values.forEach { node ->


### PR DESCRIPTION
## Description

Global search no longer surfaces the internal "Minecraft" test config (and other internal/library configs) in its option results.

`performSearch` in `Header.kt` already built the "Mods" section from the filtered `ConfigRegistry.modCardConfigs`, but the option loop iterated the unfiltered `ConfigRegistry.configs`, so options from configs that are hidden from the mods grid still leaked into search.

The option loop now skips configs via a new `ConfigRegistry.shouldShowInSearch` predicate. That predicate reuses the existing `hiddenModCardIds` set so there is one source of truth, but it keeps `oneconfig.json` (Preferences) and `themes.json` (Themes) searchable. Those two are hidden from the mods grid only because they have dedicated screens, and their settings (for example "Search Distance") must still be findable in global search.

The mods grid is unchanged: `modCardConfigs` / `shouldShowModCard` still hide the same configs they did before.

## Related Issue(s)

Fixes #668

## Checklist

- [x] I made a clear description of what was changed
- [x] I stated why these changes were necessary
- [x] I updated documentation or said what needs to be updated
- [x] I made sure these changes are backwards compatible
- [x] This pull request is for one feature/bug fix

AI was used for assistance.
