### PR TITLE
fix: dispatch ServerJoinEvent once the play connection is established

### DIFF
--- a/minecraft/src/main/java/org/polyfrost/oneconfig/internal/mixin/events/Mixin_ServerJoinEvent.java
+++ b/minecraft/src/main/java/org/polyfrost/oneconfig/internal/mixin/events/Mixin_ServerJoinEvent.java
@@ -1,6 +1,6 @@
 package org.polyfrost.oneconfig.internal.mixin.events;
 
-import net.minecraft.client.multiplayer.ClientHandshakePacketListenerImpl;
+import net.minecraft.client.multiplayer.ClientPacketListener;
 import org.polyfrost.oneconfig.api.event.v1.EventManager;
 import org.polyfrost.oneconfig.api.event.v1.events.ServerJoinEvent;
 import org.spongepowered.asm.mixin.Mixin;
@@ -8,14 +8,10 @@ import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
-@Mixin(ClientHandshakePacketListenerImpl.class)
+@Mixin(ClientPacketListener.class)
 public class Mixin_ServerJoinEvent {
 
-    //? < 1.21.4 {
-    /*@Inject(method = "handleGameProfile", at = @At("RETURN"))
-    *///? } else {
-    @Inject(method = "handleLoginFinished", at = @At("RETURN"))
-    //? }
+    @Inject(method = "handleLogin", at = @At("RETURN"))
     private void onLoginSuccess(CallbackInfo ci) {
         EventManager.INSTANCE.post(ServerJoinEvent.INSTANCE);
     }


### PR DESCRIPTION
## Description

`ServerJoinEvent` was posted from the `RETURN` of the login-handshake handler on `ClientHandshakePacketListenerImpl` (`handleLoginFinished` on 1.21.4+, `handleGameProfile` on 1.21.1). That handler runs during the login handshake, before the play phase begins, so at that point `Minecraft.getCurrentServer()` is still null. Any handler reading `mc.currentServer` from a `ServerJoinEvent` therefore received null, as reported.

This re-targets the mixin to the play-phase listener `ClientPacketListener` and injects at the `RETURN` of `handleLogin`, which is where the play connection and world are established and `currentServer` is populated. The event still fires exactly once per join, just at a point where the current-server state is actually available.

Because `handleLogin` has a stable name across every supported version (1.21.1 through 1.21.11), the previous `handleGameProfile` / `handleLoginFinished` version conditional is no longer needed and has been removed, leaving a single injection target. The event object and the `EventManager.INSTANCE.post(ServerJoinEvent.INSTANCE)` wiring are unchanged.

## Related Issue(s)

Fixes #604

## Checklist

- [x] I made a clear description of what was changed
- [x] I stated why these changes were necessary
- [x] I updated documentation or said what needs to be updated
- [x] I made sure these changes are backwards compatible
- [x] This pull request is for one feature/bug fix
