### PR TITLE
fix: FrameBufferEvent and ChatSendEvent mixins

### DIFF
--- a/minecraft/src/main/java/org/polyfrost/oneconfig/internal/mixin/events/Mixin_ChatSendEvent.java
+++ b/minecraft/src/main/java/org/polyfrost/oneconfig/internal/mixin/events/Mixin_ChatSendEvent.java
@@ -1,6 +1,6 @@
 package org.polyfrost.oneconfig.internal.mixin.events;
 
-import net.minecraft.client.player.LocalPlayer;
+import net.minecraft.client.multiplayer.ClientPacketListener;
 import org.polyfrost.oneconfig.api.event.v1.EventManager;
 import org.polyfrost.oneconfig.api.event.v1.events.ChatEvent;
 import org.spongepowered.asm.mixin.Mixin;
@@ -10,35 +10,31 @@ import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.ModifyVariable;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
-@Mixin(LocalPlayer.class)
+@Mixin(ClientPacketListener.class)
 public abstract class Mixin_ChatSendEvent {
-//    @Unique private ChatEvent.Send ocfg$chatEvent;
-//
-//    @Inject(
-//            method = "sendChat",
-//            at = @At("HEAD"),
-//            cancellable = true
-//    )
-//    public void chatCallback(String message, CallbackInfo ci) {
-//        // if (org.polyfrost.oneconfig.internal.libs.fabric.ClientCommandInternals.executeCommand(message)) {
-//        //     ci.cancel();
-//        // }
-//
-//        ocfg$chatEvent = new ChatEvent.Send(message);
-//        EventManager.INSTANCE.post(ocfg$chatEvent);
-//
-//        if (ocfg$chatEvent.cancelled) {
-//            ci.cancel();
-//        }
-//    }
-//
-//    @ModifyVariable(
-//            method = "sendChat",
-//            at = @At("HEAD"),
-//            ordinal = 0,
-//            argsOnly = true
-//    )
-//    public String modifyMessage(String message) {
-//        return ocfg$chatEvent != null ? ocfg$chatEvent.message : message;
-//    }
+    @Unique private ChatEvent.Send ocfg$chatEvent;
+
+    @Inject(
+            method = "sendChat",
+            at = @At("HEAD"),
+            cancellable = true
+    )
+    public void chatCallback(String message, CallbackInfo ci) {
+        ocfg$chatEvent = new ChatEvent.Send(message);
+        EventManager.INSTANCE.post(ocfg$chatEvent);
+
+        if (ocfg$chatEvent.cancelled) {
+            ci.cancel();
+        }
+    }
+
+    @ModifyVariable(
+            method = "sendChat",
+            at = @At("HEAD"),
+            ordinal = 0,
+            argsOnly = true
+    )
+    public String modifyMessage(String message) {
+        return ocfg$chatEvent != null ? ocfg$chatEvent.message : message;
+    }
 }

--- a/minecraft/src/main/java/org/polyfrost/oneconfig/internal/mixin/events/Mixin_FramebufferRenderEvent.java
+++ b/minecraft/src/main/java/org/polyfrost/oneconfig/internal/mixin/events/Mixin_FramebufferRenderEvent.java
@@ -11,20 +11,30 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 @Mixin(Minecraft.class)
 public class Mixin_FramebufferRenderEvent {
 
-    @Inject(method = "runTick", at = @At(value = "INVOKE",
-            //? >= 1.21.4 {
-            target = "Lcom/mojang/blaze3d/platform/Window;updateDisplay(Lcom/mojang/blaze3d/TracyFrameCapture;)V"
-            //? } else
+    //~ if >= 26.1 'runTick' -> 'renderFrame'
+    @Inject(method = "renderFrame", at = @At(value = "INVOKE",
+            //? if >= 26.2 {
+            /*target = "Lcom/mojang/blaze3d/systems/GpuSurface;present()V"
+            *///?} elif 26.1 {
+            target = "Lcom/mojang/blaze3d/systems/RenderSystem;flipFrame(Lcom/mojang/blaze3d/TracyFrameCapture;)V"
+            //?} elif >= 1.21.4 {
+            /*target = "Lcom/mojang/blaze3d/platform/Window;updateDisplay(Lcom/mojang/blaze3d/TracyFrameCapture;)V"
+            *///?} else
             //target = "Lcom/mojang/blaze3d/platform/Window;updateDisplay()V"
     ))
     private void preFramebufferRenderCallback(CallbackInfo ci) {
         EventManager.INSTANCE.post(FramebufferRenderEvent.Start.INSTANCE);
     }
 
-    @Inject(method = "runTick", at = @At(value = "INVOKE",
-            //? >= 1.21.4 {
-            target = "Lcom/mojang/blaze3d/platform/Window;updateDisplay(Lcom/mojang/blaze3d/TracyFrameCapture;)V",
-            //? } else
+    //~ if >= 26.1 'runTick' -> 'renderFrame'
+    @Inject(method = "renderFrame", at = @At(value = "INVOKE",
+            //? if >= 26.2 {
+            /*target = "Lcom/mojang/blaze3d/systems/GpuSurface;present()V",
+            *///?} elif 26.1 {
+            target = "Lcom/mojang/blaze3d/systems/RenderSystem;flipFrame(Lcom/mojang/blaze3d/TracyFrameCapture;)V",
+            //?} elif >= 1.21.4 {
+            /*target = "Lcom/mojang/blaze3d/platform/Window;updateDisplay(Lcom/mojang/blaze3d/TracyFrameCapture;)V",
+            *///?} else
             //target = "Lcom/mojang/blaze3d/platform/Window;updateDisplay()V",
             shift = At.Shift.AFTER
     ))

--- a/minecraft/src/main/kotlin/org/polyfrost/oneconfig/internal/ui/compose/SkiaCtx.kt
+++ b/minecraft/src/main/kotlin/org/polyfrost/oneconfig/internal/ui/compose/SkiaCtx.kt
@@ -237,8 +237,8 @@ object SkiaCtx {
     fun drawComposeBlit(ctx: GuiGraphicsExtractor, block: Runnable) {
         if (!this::directContext.isInitialized) return
         //? if < 1.21.10 {
-        takeWorldSnapshotIfNeeded()
-        //? }
+        /*takeWorldSnapshotIfNeeded()
+        *///? }
         val queued = queuedDraws.toList()
         queuedDraws.clear()
         val draws = queued + { block.run() }

--- a/minecraft/src/main/kotlin/org/polyfrost/oneconfig/internal/ui/services/GLInterfaceFactory.kt
+++ b/minecraft/src/main/kotlin/org/polyfrost/oneconfig/internal/ui/services/GLInterfaceFactory.kt
@@ -65,7 +65,7 @@ internal object GLInterfaceFactory {
         //? if >=26.1
         override fun getDescriptor(): Callback.Descriptor = DESCRIPTOR
         //? if <26.1
-        /*override fun getCallInterface(): FFICIF = CALL_INTERFACE*/
+        //override fun getCallInterface(): FFICIF = CALL_INTERFACE
 
         override fun callback(ret: Long, args: Long) {
             var addr = 0L

--- a/minecraft/src/main/kotlin/org/polyfrost/oneconfig/internal/ui/services/VulkanModVulkanService.kt
+++ b/minecraft/src/main/kotlin/org/polyfrost/oneconfig/internal/ui/services/VulkanModVulkanService.kt
@@ -1,7 +1,7 @@
 package org.polyfrost.oneconfig.internal.ui.services
 
 //? vulkanmod {
-/*import com.mojang.blaze3d.pipeline.RenderTarget
+import com.mojang.blaze3d.pipeline.RenderTarget
 import net.vulkanmod.gl.VkGlTexture
 import net.vulkanmod.vulkan.Renderer
 import net.vulkanmod.vulkan.device.DeviceManager
@@ -240,4 +240,4 @@ class VulkanModVulkanService private constructor(
         }
     }
 }
-*///? }
+//? }


### PR DESCRIPTION
## Description
Fixed two mixins for events I needed to use:
- Fixed FrameBufferEvent not being fired on >=26.1 due to api changes
- Fixed ChatSendEvent targeting wrong class (`LocalPlayer` → `ClientPacketListener`) (this mixin was previously commented out after modern migration)

Unrelated:
- Fixed incorrect stonecutter comments in 3 files that caused diffs when resetting stonecutter VCS to 26.1

## Related Issue(s)

<!-- List the issue(s) this PR solves -->

## Checklist

- [x] I made a clear description of what was changed
- [x] I stated why these changes were necessary
- [ ] I updated documentation or said what needs to be updated
- [x] I made sure these changes are backwards compatible
- [] This pull request is for one feature/bug fix
