### PR TITLE
fix: use functional interface for GL callback

### DIFF
--- a/minecraft/src/main/kotlin/org/polyfrost/oneconfig/internal/ui/services/GLInterfaceFactory.kt
+++ b/minecraft/src/main/kotlin/org/polyfrost/oneconfig/internal/ui/services/GLInterfaceFactory.kt
@@ -58,29 +58,22 @@ internal object GLInterfaceFactory {
         }
     }
 
-    private class GetProcCallback(
-        private val provider: FunctionProvider,
-    ) : CallbackI {
-
+    @FunctionalInterface
+    private fun interface GetProcCallbackI : CallbackI {
         //? if >=26.1
         override fun getDescriptor(): Callback.Descriptor = DESCRIPTOR
         //? if <26.1
         //override fun getCallInterface(): FFICIF = CALL_INTERFACE
 
         override fun callback(ret: Long, args: Long) {
-            var addr = 0L
-            try {
-                val namePtr = MemoryUtil.memGetAddress(
-                    MemoryUtil.memGetAddress(args + Pointer.POINTER_SIZE.toLong())
-                )
-                if (namePtr != 0L) {
-                    addr = provider.getFunctionAddress(MemoryUtil.memUTF8(namePtr))
-                }
-            } catch (_: Throwable) {
-                addr = 0L
-            }
-            APIUtil.apiClosureRetP(ret, addr)
+            val contextPtr = MemoryUtil.memGetAddress(MemoryUtil.memGetAddress(args))
+            val namePtr = MemoryUtil.memGetAddress(
+                MemoryUtil.memGetAddress(args + Pointer.POINTER_SIZE.toLong())
+            )
+            APIUtil.apiClosureRetP(ret, invoke(contextPtr, namePtr))
         }
+
+        fun invoke(context: Long, name: Long): Long
 
         companion object {
             private val CALL_INTERFACE: FFICIF = APIUtil.apiCreateCIF(
@@ -91,6 +84,17 @@ internal object GLInterfaceFactory {
             )
             //? if >=26.1
             private val DESCRIPTOR: Callback.Descriptor = Callback.Descriptor(MethodHandles.lookup(), CALL_INTERFACE)
+        }
+    }
+
+    private class GetProcCallback(
+        private val provider: FunctionProvider,
+    ) : GetProcCallbackI {
+
+        override fun invoke(context: Long, name: Long): Long = try {
+            if (name != 0L) provider.getFunctionAddress(MemoryUtil.memUTF8(name)) else 0L
+        } catch (_: Throwable) {
+            0L
         }
     }
 }


### PR DESCRIPTION
## Description

Changes the Skiko OpenGL address callback to use a functional interface, fixing OneConfig GUI not initializing on wayland.

MC 26.2 uses `org.lwjgl:lwjgl:3.4.1:unsafe`, which falls back to libffi callbacks and hides this issue.

But 26.1, https://github.com/moehreag/legacy-lwjgl3 (for Ornithe), and eventually 26.3 all use regular LWJGL builds with FFM upcalls in Java 25.

LWJGL requires the FFM upcall interface to be annotated with `@FunctionalInterface`, currently causing this error on 26.1 Wayland:
```java
[20:30:02] [Render thread/WARN] (GLInterfaceFactory) GLInterfaceFactory: failed to create getProc closure

java.lang.UnsupportedOperationException: The upcall interface must be annotated with @FunctionalInterface
	at knot//org.lwjgl.system.ffm.BCCallUp.<init>(BCCallUp.java:52)
	at knot//org.lwjgl.system.ffm.FFM.ffmUpcall(FFM.java:697)
	...
```

Tested manually to work on Wayland on 1.21, 26.1, 26.2

<!-- Describe your changes in detail -->

## Related Issue(s)

<!-- List the issue(s) this PR solves -->

## Checklist

- [x] I made a clear description of what was changed
- [x] I stated why these changes were necessary
- [ ] I updated documentation or said what needs to be updated
- [x] I made sure these changes are backwards compatible
- [x] This pull request is for one feature/bug fix
