### PR TITLE
Fix cursor not being hidden on Wayland

### DIFF
--- a/minecraft/src/main/kotlin/org/polyfrost/oneconfig/internal/ui/compose/ComposeSceneContextImpl.kt
+++ b/minecraft/src/main/kotlin/org/polyfrost/oneconfig/internal/ui/compose/ComposeSceneContextImpl.kt
@@ -68,7 +68,6 @@ private class PlatformImpl : PlatformContext {
     override val screenReader: PlatformScreenReader = PlatformScreenReaderImpl()
     override val inputModeManager: InputModeManager = InputModeManagerImpl()
 
-    private val defaultCursor = glfwCreateStandardCursor(GLFW_ARROW_CURSOR)
     private val handCursor = glfwCreateStandardCursor(GLFW_HAND_CURSOR)
     private val textCursor = glfwCreateStandardCursor(GLFW_IBEAM_CURSOR)
     private val moveCursor = glfwCreateStandardCursor(GLFW_CROSSHAIR_CURSOR)
@@ -88,7 +87,7 @@ private class PlatformImpl : PlatformContext {
 
     private fun applyPointerIcon(pointerIcon: PointerIcon) {
         when (pointerIcon) {
-            PointerIcon.Default -> glfwSetCursor(handle, defaultCursor)
+            PointerIcon.Default -> glfwSetCursor(handle, 0L)
             PointerIcon.Hand -> glfwSetCursor(handle, handCursor)
             PointerIcon.Text -> glfwSetCursor(handle, textCursor)
             PointerIcon.Crosshair -> glfwSetCursor(handle, moveCursor)


### PR DESCRIPTION
## Description
`PointerIcon.Default` previously set an explicit arrow cursor, which leaves the cursor visible after closing Oneconfig on Wayland:
<img width="300" alt="image" src="https://github.com/user-attachments/assets/1199a565-d824-4b20-880a-b2ef9da36c17" />

This PR fixes this by making `PointerIcon.Default` set `0L` instead of `defaultCursor` , which is the documented way (https://www.glfw.org/docs/3.4/input_guide.html#cursor_set) to restore the default cursor. 

Voxelcore did the same fix: https://github.com/MihailRis/voxelcore/commit/6896fa433ca2a5f6bfd5205072edfaded7107a42 


<!-- Describe your changes in detail -->

## Related Issue(s)

<!-- List the issue(s) this PR solves -->

## Checklist

- [x] I made a clear description of what was changed
- [x] I stated why these changes were necessary
- [] I updated documentation or said what needs to be updated
- [x] I made sure these changes are backwards compatible
- [x] This pull request is for one feature/bug fix
