### PR TITLE
refactor(platform): centralize screen access

### DIFF
--- a/minecraft/src/main/java/org/polyfrost/oneconfig/api/platform/v1/internal/ScreenPlatformImpl.java
+++ b/minecraft/src/main/java/org/polyfrost/oneconfig/api/platform/v1/internal/ScreenPlatformImpl.java
@@ -69,6 +69,16 @@ public class ScreenPlatformImpl implements ScreenPlatform {
         return Minecraft.getInstance().getWindow().getScreenHeight();
     }
 
+    @Override
+    public int guiWidth() {
+        return Minecraft.getInstance().getWindow().getGuiScaledWidth();
+    }
+
+    @Override
+    public int guiHeight() {
+        return Minecraft.getInstance().getWindow().getGuiScaledHeight();
+    }
+
     // On macOS, glfwGetWindowContentScale == framebufferSize / windowSize (e.g. 2.0 on Retina).
     // On Windows, they differ: framebuffer == window (ratio 1.0), but contentScale reflects DPI (e.g. 1.5).
     // Using contentScale as pixelRatio on Windows caused the UI to be rendered at the wrong size (#478).
@@ -118,11 +128,8 @@ public class ScreenPlatformImpl implements ScreenPlatform {
     @Override
     @SuppressWarnings("unchecked" /*, reason = "reduces friction between versions" */)
     public <T> @Nullable T current() {
-        //? if >= 26.2 {
-        /*return (T) Minecraft.getInstance().gui.screen();
-        *///?} else {
+        //~ if >= 26.2 '.screen' -> '.gui.screen()'
         return (T) Minecraft.getInstance().screen;
-        //?}
     }
 
 }

--- a/minecraft/src/main/java/org/polyfrost/oneconfig/internal/OneConfig.java
+++ b/minecraft/src/main/java/org/polyfrost/oneconfig/internal/OneConfig.java
@@ -108,11 +108,7 @@ public class OneConfig
     }
 
     public static boolean isInChatScreen() {
-        //? if >= 26.2 {
-        /*return Minecraft.getInstance().gui.screen() instanceof ChatScreen;
-        *///?} else {
-        return Minecraft.getInstance().screen instanceof ChatScreen;
-        //?}
+        return Platform.screen().current() instanceof ChatScreen;
     }
 
     private static void registerKeybinds() {
@@ -164,8 +160,8 @@ public class OneConfig
             return;
         }
 
-        float sw = graphics.guiWidth();
-        float sh = graphics.guiHeight();
+        float sw = Platform.screen().guiWidth();
+        float sh = Platform.screen().guiHeight();
         // guiWidth()/guiHeight() are already GUI-scaled (== Screen dimensions), do not divide by guiScale again.
         HudManager.guiScreenWidth = sw;
         HudManager.guiScreenHeight = sh;
@@ -179,11 +175,10 @@ public class OneConfig
         HudManager.isDebugScreenVisible = Minecraft.getInstance().getDebugOverlay().showDebugScreen();
         HudManager.isTabListVisible = isTabListVisible();
         HudManager.isGuiScreenOpen = Platform.screen().current() != null;
-        //~ if >= 26.2 'screen' -> 'gui.screen()'
-        HudManager.isChatScreenOpen = Minecraft.getInstance().screen instanceof ChatScreen;
+        HudManager.isChatScreenOpen = Platform.screen().current() instanceof ChatScreen;
         HudManager.inWorld = true;
-        HudManager.targetPixelWidth = Minecraft.getInstance().getWindow().getWidth();
-        HudManager.targetPixelHeight = Minecraft.getInstance().getWindow().getHeight();
+        HudManager.targetPixelWidth = Platform.screen().viewportWidth();
+        HudManager.targetPixelHeight = Platform.screen().viewportHeight();
 
         if (!SkiaCtx.INSTANCE.suppressInGameHudRender) {
             LegacyHudRenderer.INSTANCE.renderLive(graphics);
@@ -209,9 +204,8 @@ public class OneConfig
 
     private static void installNotificationRenderer() {
         SkiaCtx.INSTANCE.setNotifRenderer(() -> {
-            var window = Minecraft.getInstance().getWindow();
-            float sw = window.getGuiScaledWidth();
-            float sh = window.getGuiScaledHeight();
+            float sw = Platform.screen().guiWidth();
+            float sh = Platform.screen().guiHeight();
             if (sw <= 0f || sh <= 0f) return;
             var ctx = new RenderContext(SkiaCtx.INSTANCE.getCanvas());
             NotificationsRenderer.render(ctx, sw, sh);

--- a/minecraft/src/main/kotlin/org/polyfrost/oneconfig/internal/ui/compose/ComposePreloader.kt
+++ b/minecraft/src/main/kotlin/org/polyfrost/oneconfig/internal/ui/compose/ComposePreloader.kt
@@ -7,9 +7,9 @@ import androidx.compose.ui.input.pointer.PointerEventType
 import androidx.compose.ui.scene.CanvasLayersComposeScene
 import androidx.compose.ui.unit.Density
 import androidx.compose.ui.unit.IntSize
-import net.minecraft.client.Minecraft
 import org.jetbrains.skia.ImageInfo
 import org.jetbrains.skia.Surface
+import org.polyfrost.oneconfig.api.platform.v1.Platform
 import org.polyfrost.oneconfig.internal.ui.OneConfigInterface
 import org.slf4j.LoggerFactory
 
@@ -28,9 +28,8 @@ object ComposePreloader {
         gpuWarmed = true
         SkiaCtx.queueWarmup {
             val startNanos = System.nanoTime()
-            val mc = Minecraft.getInstance()
-            val w = mc.window.screenWidth.takeIf { it > 0 } ?: 1280
-            val h = mc.window.screenHeight.takeIf { it > 0 } ?: 720
+            val w = Platform.screen().windowWidth().takeIf { it > 0 } ?: 1280
+            val h = Platform.screen().windowHeight().takeIf { it > 0 } ?: 720
             // Mirror ComposeScreen: created and rendered on the render thread, default coroutineContext.
             val scene = CanvasLayersComposeScene(
                 platformContext = ComposeSceneContextImpl.platformContext,

--- a/minecraft/src/main/kotlin/org/polyfrost/oneconfig/internal/ui/compose/ComposeSceneContextImpl.kt
+++ b/minecraft/src/main/kotlin/org/polyfrost/oneconfig/internal/ui/compose/ComposeSceneContextImpl.kt
@@ -34,7 +34,7 @@ private class InputModeManagerImpl : InputModeManager {
 @ExperimentalComposeUiApi
 private class WindowInfoImpl : WindowInfo {
     override var containerSize: IntSize by mutableStateOf(
-        Minecraft.getInstance().window.let { IntSize(it.screenWidth, it.screenHeight) }
+        Platform.screen().let { IntSize(it.windowWidth(), it.windowHeight()) }
     )
 
     private fun isKeyDown(glfwKey: Int): Boolean {

--- a/minecraft/src/main/kotlin/org/polyfrost/oneconfig/internal/ui/compose/ComposeScreen.kt
+++ b/minecraft/src/main/kotlin/org/polyfrost/oneconfig/internal/ui/compose/ComposeScreen.kt
@@ -567,14 +567,14 @@ abstract class ComposeScreen(
 
     private fun syncSceneMetrics(): Boolean {
         if (sceneClosed) return false
-        val w = client.window.screenWidth
-        val h = client.window.screenHeight
+        val w = Platform.screen().windowWidth()
+        val h = Platform.screen().windowHeight()
         if (w <= 0 || h <= 0) return false
         scene.density = Density(sceneDensity())
         scene.size = IntSize(w, h)
         ComposeSceneContextImpl.updateContainerSize(w, h)
         val changed = w != lastSceneW || h != lastSceneH
-        val fbW = client.window.width
+        val fbW = Platform.screen().viewportWidth()
         if (changed || fbW != lastFbWidth) {
             cachedSurfaceScale = -1f
             settleFrames = SETTLE_FRAMES
@@ -598,9 +598,9 @@ abstract class ComposeScreen(
 
     private fun surfaceScale(): Float {
         cachedSurfaceScale.takeIf { it > 0f }?.let { return it }
-        val screenW = client.window.screenWidth
+        val screenW = Platform.screen().windowWidth()
         val scale = if (screenW <= 0) Platform.screen().pixelRatio().takeIf { it > 0f } ?: 1f
-        else (client.window.width.toFloat() / screenW).coerceAtLeast(0.01f)
+        else (Platform.screen().viewportWidth().toFloat() / screenW).coerceAtLeast(0.01f)
         cachedSurfaceScale = scale
         return scale
     }

--- a/minecraft/src/main/kotlin/org/polyfrost/oneconfig/internal/ui/compose/SkiaCtx.kt
+++ b/minecraft/src/main/kotlin/org/polyfrost/oneconfig/internal/ui/compose/SkiaCtx.kt
@@ -15,6 +15,7 @@ import org.lwjgl.opengl.GL11
 import org.lwjgl.opengl.GL30
 import org.polyfrost.oneconfig.api.notifications.v1.NotificationsManager
 import org.polyfrost.oneconfig.api.platform.v1.ModInfo
+import org.polyfrost.oneconfig.api.platform.v1.Platform
 import org.polyfrost.oneconfig.internal.ui.compose.opengl.StoredGLState
 import org.polyfrost.oneconfig.internal.ui.services.VulkanService
 import org.slf4j.LoggerFactory
@@ -308,7 +309,7 @@ object SkiaCtx {
         //? if < 26.1 {
         /*if (!this::directContext.isInitialized) return
         if (isVulkanMode) return
-        if (client.screen !is ComposeScreen) return
+        if (Platform.screen().current<Any>() !is ComposeScreen) return
         val w = target.width
         val h = target.height
         if (w <= 0 || h <= 0) return
@@ -576,8 +577,8 @@ object SkiaCtx {
     }
 
     private fun resolveHudSurface(): Surface? {
-        val w = client.window.width
-        val h = client.window.height
+        val w = Platform.screen().viewportWidth()
+        val h = Platform.screen().viewportHeight()
         if (w <= 0 || h <= 0) return null
 
         var rt = hudTarget
@@ -638,8 +639,8 @@ object SkiaCtx {
     }
 
     private fun resolveComposeSurface(): Surface? {
-        val w = client.window.width
-        val h = client.window.height
+        val w = Platform.screen().viewportWidth()
+        val h = Platform.screen().viewportHeight()
         if (w <= 0 || h <= 0) return null
 
         var rt = composeTarget
@@ -702,8 +703,8 @@ object SkiaCtx {
 
     private fun resolveGLSurface(): Surface? {
         val svc = vulkanService ?: return null
-        val w = client.window.width
-        val h = client.window.height
+        val w = Platform.screen().viewportWidth()
+        val h = Platform.screen().viewportHeight()
         if (w <= 0 || h <= 0) return null
         val existing = glSurface
         if (existing != null && existing.width == w && existing.height == h) return existing
@@ -746,8 +747,8 @@ object SkiaCtx {
         val (vkImg, vkFmt, queueFamily) = svc.getMainColorImageInfo()
         if (vkImg == 0L) return null
 
-        val w = client.window.width
-        val h = client.window.height
+        val w = Platform.screen().viewportWidth()
+        val h = Platform.screen().viewportHeight()
         if (w <= 0 || h <= 0) return null
 
         if (w != vkSurfaceWidth || h != vkSurfaceHeight || svc.offscreenNeedsPerFrameRewrap) {

--- a/minecraft/src/main/kotlin/org/polyfrost/oneconfig/internal/ui/compose/impls/HudEditorUIScreen.kt
+++ b/minecraft/src/main/kotlin/org/polyfrost/oneconfig/internal/ui/compose/impls/HudEditorUIScreen.kt
@@ -101,8 +101,8 @@ class HudEditorUIScreen : ComposeScreen() {
         }
         if (client.level == null) {
             HudManager.inWorld = false
-            val sw = ctx.guiWidth().toFloat()
-            val sh = ctx.guiHeight().toFloat()
+            val sw = Platform.screen().guiWidth().toFloat()
+            val sh = Platform.screen().guiHeight().toFloat()
             HudManager.guiScreenWidth = sw
             HudManager.guiScreenHeight = sh
             HudManager.prepare(sw, sh)

--- a/minecraft/src/main/kotlin/org/polyfrost/oneconfig/internal/ui/compose/impls/OneConfigUIScreen.kt
+++ b/minecraft/src/main/kotlin/org/polyfrost/oneconfig/internal/ui/compose/impls/OneConfigUIScreen.kt
@@ -230,8 +230,8 @@ class OneConfigUIScreen @JvmOverloads constructor(
         }
         if (client.level == null) {
             HudManager.inWorld = false
-            val sw = ctx.guiWidth().toFloat()
-            val sh = ctx.guiHeight().toFloat()
+            val sw = Platform.screen().guiWidth().toFloat()
+            val sh = Platform.screen().guiHeight().toFloat()
             HudManager.guiScreenWidth = sw
             HudManager.guiScreenHeight = sh
             HudManager.prepare(sw, sh)

--- a/minecraft/src/main/kotlin/org/polyfrost/oneconfig/internal/ui/hud/DebugOverlayOffscreen.kt
+++ b/minecraft/src/main/kotlin/org/polyfrost/oneconfig/internal/ui/hud/DebugOverlayOffscreen.kt
@@ -63,8 +63,8 @@ object DebugOverlayOffscreen {
     fun render() {
         hasContent = false
         if (!active()) return
-        val w = client.window.width
-        val h = client.window.height
+        val w = Platform.screen().viewportWidth()
+        val h = Platform.screen().viewportHeight()
         if (w <= 0 || h <= 0) return
 
         try {
@@ -94,7 +94,7 @@ object DebugOverlayOffscreen {
 
         val state = GuiRenderState()
         //? if >= 1.21.11 {
-        val ext = GuiGraphicsExtractor(client, state, client.window.guiScaledWidth, client.window.guiScaledHeight)
+        val ext = GuiGraphicsExtractor(client, state, Platform.screen().guiWidth(), Platform.screen().guiHeight())
         //? } else
         /*val ext = GuiGraphicsExtractor(client, state)*/
         capturing = true

--- a/minecraft/src/main/kotlin/org/polyfrost/oneconfig/internal/ui/hud/LegacyHudOffscreen.kt
+++ b/minecraft/src/main/kotlin/org/polyfrost/oneconfig/internal/ui/hud/LegacyHudOffscreen.kt
@@ -91,8 +91,8 @@ object LegacyHudOffscreen {
         val huds = activeLegacyHuds()
         if (huds.isEmpty() && !CompatOverlayRenderer.hasHooks()) return
         if (!SkiaCtx.isReady) return
-        val w = client.window.width
-        val h = client.window.height
+        val w = Platform.screen().viewportWidth()
+        val h = Platform.screen().viewportHeight()
         if (w <= 0 || h <= 0) return
 
         try {
@@ -101,8 +101,8 @@ object LegacyHudOffscreen {
             val guiRenderer = (client.gameRenderer as GameRendererAccessor).`oneconfig$getGuiRenderer`()
             val accessor = guiRenderer as GuiRendererAccessor
 
-            val guiW = client.window.guiScaledWidth
-            val guiH = client.window.guiScaledHeight
+            val guiW = Platform.screen().guiWidth()
+            val guiH = Platform.screen().guiHeight()
 
             val state = GuiRenderState()
             val ext = GuiGraphicsExtractor(client, state, guiW, guiH)

--- a/modules/utils/api/utils.api
+++ b/modules/utils/api/utils.api
@@ -155,6 +155,8 @@ public abstract interface class org/polyfrost/oneconfig/api/platform/v1/ScreenPl
 	public abstract fun current ()Ljava/lang/Object;
 	public fun display (Ljava/lang/Object;)V
 	public abstract fun display (Ljava/lang/Object;I)V
+	public abstract fun guiHeight ()I
+	public abstract fun guiWidth ()I
 	public fun mcToScreenScale ()F
 	public fun pixelRatio ()F
 	public fun screenToMcScale ()F

--- a/modules/utils/src/main/java/org/polyfrost/oneconfig/api/platform/v1/ScreenPlatform.java
+++ b/modules/utils/src/main/java/org/polyfrost/oneconfig/api/platform/v1/ScreenPlatform.java
@@ -38,6 +38,10 @@ public interface ScreenPlatform {
 
     int windowHeight();
 
+    int guiWidth();
+
+    int guiHeight();
+
     default float pixelRatio() {
         return (float) viewportWidth() / windowWidth();
     }


### PR DESCRIPTION
## Description
This PR has no actual functional changes, but makes use of `ScreenPlatform` whenever possible to make multiversion/modloader screen access easier to work with.

- Added `guiWidth` and `guiHeight` to `ScreenPlatform`
- Updated API dump

`client.window.width` -> `Platform.screen().viewportWidth()`
`client.window.height` -> `Platform.screen().viewportHeight()`

`client.window.screenWidth` -> `Platform.screen().windowWidth()`
`client.window.screenHeight` -> `Platform.screen().windowHeight()`

`graphics.guiWidth()` -> `Platform.screen().guiWidth()`
`graphics.guiHeight()` -> `Platform.screen().guiHeight()`

`Minecraft.getInstance().gui.screen` -> `Platform.screen().current()`
`Minecraft.getInstance().screen` -> `Platform.screen().current()`f

<!-- Describe your changes in detail -->

## Related Issue(s)

<!-- List the issue(s) this PR solves -->

## Checklist

- [x] I made a clear description of what was changed
- [x] I stated why these changes were necessary
- [] I updated documentation or said what needs to be updated
- [x] I made sure these changes are backwards compatible
- [x] This pull request is for one feature/bug fix
