### PR TITLE
fix: avoid unnecessary casts in screen checks

### DIFF
--- a/minecraft/src/main/kotlin/org/polyfrost/oneconfig/internal/ui/compose/ComposeScreen.kt
+++ b/minecraft/src/main/kotlin/org/polyfrost/oneconfig/internal/ui/compose/ComposeScreen.kt
@@ -302,7 +302,7 @@ abstract class ComposeScreen(
 
     private fun closeWithMessage(reason: String) {
         client.execute {
-            if (Platform.screen().current<Screen>() === this) Platform.screen().close()
+            if (Platform.screen().current<Any?>() === this) Platform.screen().close()
             Platform.screen().showMessage(reason)
         }
     }
@@ -344,7 +344,7 @@ abstract class ComposeScreen(
 
     //~ if >= 26.1 'render' -> 'extractRenderState'
     override fun extractRenderState(ctx: GuiGraphicsExtractor, mouseX: Int, mouseY: Int, tickDelta: Float) {
-        if (Platform.screen().current<Screen>() !== this) return
+        if (Platform.screen().current<Any?>() !== this) return
         if (scenePoisoned) {
             if (sceneRebuilds >= MAX_SCENE_REBUILDS) {
                 LOGGER.error(

--- a/minecraft/src/main/kotlin/org/polyfrost/oneconfig/internal/ui/compose/impls/HudEditorUIScreen.kt
+++ b/minecraft/src/main/kotlin/org/polyfrost/oneconfig/internal/ui/compose/impls/HudEditorUIScreen.kt
@@ -18,7 +18,6 @@ import androidx.lifecycle.compose.LocalLifecycleOwner
 import androidx.lifecycle.viewmodel.compose.LocalViewModelStoreOwner
 import com.mojang.blaze3d.platform.InputConstants
 import net.minecraft.client.gui.GuiGraphicsExtractor
-import net.minecraft.client.gui.screens.Screen
 //? >= 1.21.10
 import net.minecraft.client.input.KeyEvent
 import org.polyfrost.oneconfig.api.hud.v1.HudManager
@@ -115,7 +114,7 @@ class HudEditorUIScreen : ComposeScreen() {
     override fun extractRenderState(ctx: GuiGraphicsExtractor, mouseX: Int, mouseY: Int, tickDelta: Float) {
         // A screen drawn over this one may render it as its parent; don't act on that pass (it would close
         // the screen on top of us, among other things).
-        if (Platform.screen().current<Screen>() !== this) return
+        if (Platform.screen().current<Any?>() !== this) return
         if (closeRequested && System.currentTimeMillis() - closeRequestedAt >= closeAnimationMs) {
             Platform.screen().close()
             return

--- a/minecraft/src/main/kotlin/org/polyfrost/oneconfig/internal/ui/compose/impls/OneConfigUIScreen.kt
+++ b/minecraft/src/main/kotlin/org/polyfrost/oneconfig/internal/ui/compose/impls/OneConfigUIScreen.kt
@@ -6,7 +6,6 @@ import androidx.compose.ui.graphics.skiaCanvas
 import androidx.compose.ui.platform.LocalWindowInfo
 import com.mojang.blaze3d.platform.InputConstants
 import net.minecraft.client.gui.GuiGraphicsExtractor
-import net.minecraft.client.gui.screens.Screen
 //? >= 1.21.10
 import net.minecraft.client.input.KeyEvent
 //? >= 1.21.10
@@ -272,7 +271,7 @@ class OneConfigUIScreen @JvmOverloads constructor(
         // over their parent and render that parent by hand every frame. When the parent is this screen that
         // would queue a fullscreen blur into the Skia pass, which runs after vanilla GUI drawing and so smears
         // the popup on top of it. Nothing here may run unless we are the screen actually being shown.
-        if (Platform.screen().current<Screen>() !== this) return
+        if (Platform.screen().current<Any?>() !== this) return
         if (closeRequested && System.currentTimeMillis() - closeRequestedAt >= closeAnimationMs) {
             Platform.screen().close()
             return

--- a/minecraft/src/main/kotlin/org/polyfrost/oneconfig/internal/ui/hud/DebugOverlayOffscreen.kt
+++ b/minecraft/src/main/kotlin/org/polyfrost/oneconfig/internal/ui/hud/DebugOverlayOffscreen.kt
@@ -3,7 +3,6 @@ package org.polyfrost.oneconfig.internal.ui.hud
 import com.mojang.blaze3d.pipeline.TextureTarget
 import net.minecraft.client.Minecraft
 import net.minecraft.client.gui.GuiGraphicsExtractor
-import net.minecraft.client.gui.screens.Screen
 //? if >= 26.1 {
 import net.minecraft.client.renderer.state.gui.GuiRenderState
 import org.polyfrost.oneconfig.internal.mixin.render.GameRendererAccessor
@@ -54,7 +53,7 @@ object DebugOverlayOffscreen {
     private fun active(): Boolean =
         !failed &&
             SkiaCtx.isReady &&
-            Platform.screen().current<Screen>() is ComposeScreen &&
+            Platform.screen().current<Any?>() is ComposeScreen &&
             client.debugOverlay.showDebugScreen()
 
     /** Called from the debug overlay mixin: hide the vanilla (under-UI, blurred) copy. */


### PR DESCRIPTION
## Description
No functional changes. Use `Any?` instead of `Screen` when the current screen is only being compared/type checked, avoiding unnecessary `Screen` casts (and makes Ornithe porting slightly easier)

## Checklist

- [x] I made a clear description of what was changed
- [x] I stated why these changes were necessary
- [ ] I updated documentation or said what needs to be updated
- [x] I made sure these changes are backwards compatible
- [x] This pull request is for one feature/bug fix
