### PR TITLE
fix(keybinds): disallow combos for minecraft keybinds

### DIFF
--- a/minecraft/src/main/kotlin/org/polyfrost/oneconfig/internal/ui/keybind/MinecraftKeybindProvider.kt
+++ b/minecraft/src/main/kotlin/org/polyfrost/oneconfig/internal/ui/keybind/MinecraftKeybindProvider.kt
@@ -87,6 +87,7 @@ object MinecraftKeybindProvider : KeybindGroupProvider {
         )
         prop.addMetadata("visualizer", Visualizer.KeybindVisualizer::class.java)
         prop.addMetadata("singleKey", true)
+        prop.addMetadata("default", mapping.defaultKey.toOneConfigKeybind())
         prop.addMetadata("category", categoryLabel(mapping))
         prop.addMetadata("subcategory", "Minecraft Controls")
         return prop
@@ -156,13 +157,17 @@ object MinecraftKeybindProvider : KeybindGroupProvider {
 
     private fun KeyMapping.toOneConfigKeybind(): OneConfigKeybind {
         val key = runCatching { InputConstants.getKey(saveString()) }.getOrDefault(InputConstants.UNKNOWN)
-        return when (key.type) {
+        return key.toOneConfigKeybind()
+    }
+
+    private fun InputConstants.Key.toOneConfigKeybind(): OneConfigKeybind {
+        return when (type) {
             InputConstants.Type.KEYSYM -> {
-                if (key.value > 0) OneConfigKeybind(intArrayOf(key.value), null, KeyModifiers.NONE, 0L) { true }
+                if (value > 0) OneConfigKeybind(intArrayOf(value), null, KeyModifiers.NONE, 0L) { true }
                 else OneConfigKeybind(null, null, KeyModifiers.NONE, 0L) { true }
             }
             InputConstants.Type.MOUSE -> {
-                if (key.value >= 0) OneConfigKeybind(null, intArrayOf(key.value), KeyModifiers.NONE, 0L) { true }
+                if (value >= 0) OneConfigKeybind(null, intArrayOf(value), KeyModifiers.NONE, 0L) { true }
                 else OneConfigKeybind(null, null, KeyModifiers.NONE, 0L) { true }
             }
             else -> OneConfigKeybind(null, null, KeyModifiers.NONE, 0L) { true }

--- a/minecraft/src/main/kotlin/org/polyfrost/oneconfig/internal/ui/keybind/MinecraftKeybindProvider.kt
+++ b/minecraft/src/main/kotlin/org/polyfrost/oneconfig/internal/ui/keybind/MinecraftKeybindProvider.kt
@@ -86,6 +86,7 @@ object MinecraftKeybindProvider : KeybindGroupProvider {
             OneConfigKeybind::class.java,
         )
         prop.addMetadata("visualizer", Visualizer.KeybindVisualizer::class.java)
+        prop.addMetadata("singleKey", true)
         prop.addMetadata("category", categoryLabel(mapping))
         prop.addMetadata("subcategory", "Minecraft Controls")
         return prop

--- a/modules/internal/src/main/kotlin/org/polyfrost/oneconfig/internal/ui/components/settings/KeybindOption.kt
+++ b/modules/internal/src/main/kotlin/org/polyfrost/oneconfig/internal/ui/components/settings/KeybindOption.kt
@@ -115,6 +115,7 @@ private fun KeyEvent.awtKeyEventId(): Int? = runCatching {
 @Composable
 fun KeybindOption(data: KeybindOptionData) {
     val theme = LocalTheme.current
+    val singleKey = data.prop.getMetadata<Boolean>("singleKey") == true
     val interactionSource = rememberInteractionSource()
     val isHovered by interactionSource.collectIsHoveredAsState()
     var recording by remember(data.prop) { mutableStateOf(false) }
@@ -213,6 +214,11 @@ fun KeybindOption(data: KeybindOptionData) {
                         // would match nothing useful (or, for code 0, match everything).
                         val glfwCode = event.utf16CodePoint
                         if (glfwCode <= 0) return@onKeyEvent true
+                        if (singleKey) {
+                            applyKeybind(intArrayOf(glfwCode), null)
+                            recording = false
+                            return@onKeyEvent true
+                        }
                         if (glfwCode !in recordedKeys) recordedKeys.add(glfwCode)
                         heldKeys.add(glfwCode)
                         return@onKeyEvent true


### PR DESCRIPTION
## Description
fix(keybinds): disallow combos for minecraft keybinds
- Currently users can set combo keybinds for defualt MC keybinds, but they dont work correctly since MC keybinds don't accept combos
- Reflect vanilla behaviour for minecraft default keybinds, dont let users set combos for them

fix(keybinds): allow reset to default for minecraft keybinds
- Reset to default did not work for default MC keybinds
- This captures default to make it work

## Checklist

- [x] I made a clear description of what was changed
- [x] I stated why these changes were necessary
- [x] I made sure these changes are backwards compatible
- [x] This pull request is for one feature/bug fix
