### PR TITLE
fix(ui): don't duplicate sound when switching themes

### DIFF
--- a/modules/internal/src/main/kotlin/org/polyfrost/oneconfig/internal/ui/screens/Themes.kt
+++ b/modules/internal/src/main/kotlin/org/polyfrost/oneconfig/internal/ui/screens/Themes.kt
@@ -2,14 +2,13 @@ package org.polyfrost.oneconfig.internal.ui.screens
 
 import androidx.compose.animation.animateColorAsState
 import androidx.compose.animation.core.animateDpAsState
-import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
@@ -25,10 +24,8 @@ import androidx.compose.ui.input.pointer.PointerIcon
 import androidx.compose.ui.input.pointer.pointerHoverIcon
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.unit.dp
-import org.polyfrost.oneconfig.internal.ThemeConfig
 import org.polyfrost.oneconfig.internal.ui.api.ConfigRegistry
 import org.polyfrost.oneconfig.internal.ui.components.Text
-import org.polyfrost.oneconfig.internal.ui.components.onClick
 import org.polyfrost.oneconfig.internal.ui.components.rememberInteractionSource
 import org.polyfrost.oneconfig.internal.ui.shell.ShellState
 import org.polyfrost.oneconfig.internal.ui.themes.Accent
@@ -83,7 +80,10 @@ private fun ThemeCard(theme: UITheme) {
         modifier = Modifier
             .background(LocalTheme.current.modCardBackground, LocalTheme.current.backgroundShape)
             .border(borderWidth, borderColor, LocalTheme.current.backgroundShape)
-            .onClick(interactionSource) { ThemeRegistry.activate(theme) }
+            .clickable(interactionSource, indication = null) {
+                // Use clickable because onClick always plays CLICK. ThemeRegistry.activate chooses CLICK or OPEN
+                ThemeRegistry.activate(theme)
+            }
             .pointerHoverIcon(PointerIcon.Hand)
             .padding(14.dp),
         verticalArrangement = Arrangement.spacedBy(14.dp),

--- a/modules/internal/src/main/kotlin/org/polyfrost/oneconfig/internal/ui/themes/ThemeRegistry.kt
+++ b/modules/internal/src/main/kotlin/org/polyfrost/oneconfig/internal/ui/themes/ThemeRegistry.kt
@@ -7,6 +7,7 @@ import androidx.compose.runtime.mutableStateOf
 import org.polyfrost.oneconfig.api.config.v1.ConfigManager
 import org.polyfrost.oneconfig.internal.ThemeConfig
 import org.polyfrost.oneconfig.internal.ui.api.settings.BuiltinVisualizers
+import org.polyfrost.oneconfig.internal.ui.sound.UiSoundEvent
 import org.polyfrost.oneconfig.internal.ui.sound.UiSounds
 import org.polyfrost.oneconfig.internal.ui.sound.UiSoundTheme
 
@@ -40,8 +41,12 @@ object ThemeRegistry {
         ThemeConfig.activeTheme = theme.name
         syncNotificationTheme(theme)
         saveThemeToConfig()
-        if (previous != null && UiSoundTheme.of(previous) != UiSoundTheme.of(theme)) {
-            UiSounds.onSoundThemeChanged()
+        if (previous != null) {
+            if (UiSoundTheme.of(previous) != UiSoundTheme.of(theme)) {
+                UiSounds.onSoundThemeChanged()
+            } else {
+                UiSounds.play(UiSoundEvent.CLICK)
+            }
         }
     }
 


### PR DESCRIPTION
## Description
- Previously, `.onClick` always played CLICK, but switching theme families also played OPEN, causing duplicated sounds
- Theme card now uses `.clickable`, and `ThemeRegistry.activate` plays either CLICK if within same family or OPEN when changing theme families

## Related Issue(s)
Fixes https://github.com/Polyfrost/OneConfig/issues/775

## Checklist

- [x] I made a clear description of what was changed
- [x] I stated why these changes were necessary
- [x] I made sure these changes are backwards compatible
- [x] This pull request is for one feature/bug fix
