### PR TITLE
Fix item list scrolling

### DIFF
--- a/modules/internal/src/main/kotlin/org/polyfrost/oneconfig/internal/ui/components/VerticalScrollContainment.kt
+++ b/modules/internal/src/main/kotlin/org/polyfrost/oneconfig/internal/ui/components/VerticalScrollContainment.kt
@@ -1,0 +1,59 @@
+package org.polyfrost.oneconfig.internal.ui.components
+
+import androidx.compose.foundation.ScrollState
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberUpdatedState
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.input.nestedscroll.NestedScrollConnection
+import androidx.compose.ui.input.nestedscroll.NestedScrollSource
+import androidx.compose.ui.input.nestedscroll.nestedScroll
+import androidx.compose.ui.input.pointer.PointerEventPass
+import androidx.compose.ui.input.pointer.PointerEventType
+import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.unit.Velocity
+
+/** keeps scroll input inside the child list. */
+@Composable
+internal fun Modifier.containVerticalScroll(scrollState: ScrollState): Modifier {
+    return containVerticalScroll { scrollState.maxValue > 0 }
+}
+
+/**
+ * catches wheel input at the list edges.
+ * keep this before the scroll modifier so the list handles it first.
+ */
+@Composable
+internal fun Modifier.containVerticalScroll(isScrollable: () -> Boolean): Modifier {
+    val currentIsScrollable = rememberUpdatedState(isScrollable)
+    val connection = remember {
+        VerticalScrollContainmentConnection { currentIsScrollable.value() }
+    }
+
+    return nestedScroll(connection)
+        .pointerInput(Unit) {
+            awaitPointerEventScope {
+                while (true) {
+                    val event = awaitPointerEvent(PointerEventPass.Main)
+                    if (event.type == PointerEventType.Scroll && currentIsScrollable.value()) {
+                        event.changes.forEach { change ->
+                            if (change.scrollDelta.y != 0f) change.consume()
+                        }
+                    }
+                }
+            }
+        }
+}
+
+private class VerticalScrollContainmentConnection(
+    private val hasScrollableContent: () -> Boolean,
+) : NestedScrollConnection {
+    override fun onPostScroll(consumed: Offset, available: Offset, source: NestedScrollSource): Offset {
+        return if (hasScrollableContent()) Offset(0f, available.y) else Offset.Zero
+    }
+
+    override suspend fun onPostFling(consumed: Velocity, available: Velocity): Velocity {
+        return if (hasScrollableContent()) Velocity(0f, available.y) else Velocity.Zero
+    }
+}

--- a/modules/internal/src/main/kotlin/org/polyfrost/oneconfig/internal/ui/components/item/ItemVisuals.kt
+++ b/modules/internal/src/main/kotlin/org/polyfrost/oneconfig/internal/ui/components/item/ItemVisuals.kt
@@ -22,6 +22,7 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.grid.GridCells
 import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
 import androidx.compose.foundation.lazy.grid.items
+import androidx.compose.foundation.lazy.grid.rememberLazyGridState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.BasicTextField
 import androidx.compose.runtime.Composable
@@ -54,6 +55,7 @@ import org.polyfrost.oneconfig.internal.ui.api.Tooltip
 import org.polyfrost.oneconfig.internal.ui.components.Icon
 import org.polyfrost.oneconfig.internal.ui.components.IconButton
 import org.polyfrost.oneconfig.internal.ui.components.Text
+import org.polyfrost.oneconfig.internal.ui.components.containVerticalScroll
 import org.polyfrost.oneconfig.internal.ui.components.localizedString
 import org.polyfrost.oneconfig.internal.ui.components.onClick
 import org.polyfrost.oneconfig.internal.ui.components.rememberInteractionSource
@@ -247,9 +249,16 @@ fun ItemGrid(
     spacing: Dp = 6.dp,
     onClick: ((ItemDescriptor) -> Unit)? = null,
 ) {
+    val gridState = rememberLazyGridState()
     LazyVerticalGrid(
         columns = GridCells.Adaptive(cellSize),
-        modifier = modifier.fillMaxWidth().heightIn(max = maxHeight),
+        state = gridState,
+        modifier = modifier
+            .fillMaxWidth()
+            .heightIn(max = maxHeight)
+            .containVerticalScroll {
+                gridState.canScrollBackward || gridState.canScrollForward
+            },
         horizontalArrangement = Arrangement.spacedBy(spacing),
         verticalArrangement = Arrangement.spacedBy(spacing),
     ) {

--- a/modules/internal/src/main/kotlin/org/polyfrost/oneconfig/internal/ui/components/settings/ItemListOption.kt
+++ b/modules/internal/src/main/kotlin/org/polyfrost/oneconfig/internal/ui/components/settings/ItemListOption.kt
@@ -49,6 +49,7 @@ fun ItemListOption(data: ItemListOptionData) {
             onAdd = { expanded = true },
             showAddWhenFull = true,
             entryHeight = ItemRowHeight,
+            containScroll = true,
         ) { entry, ctx ->
             SelectedItemRow(entry.value, itemById[entry.value], ctx)
         }

--- a/modules/internal/src/main/kotlin/org/polyfrost/oneconfig/internal/ui/components/settings/ListOptionScaffold.kt
+++ b/modules/internal/src/main/kotlin/org/polyfrost/oneconfig/internal/ui/components/settings/ListOptionScaffold.kt
@@ -46,6 +46,7 @@ import androidx.compose.ui.unit.sp
 import androidx.compose.ui.zIndex
 import org.polyfrost.oneconfig.internal.ui.components.Icon
 import org.polyfrost.oneconfig.internal.ui.components.Text
+import org.polyfrost.oneconfig.internal.ui.components.containVerticalScroll
 import org.polyfrost.oneconfig.internal.ui.components.fadingEdges
 import org.polyfrost.oneconfig.internal.ui.components.onClick
 import org.polyfrost.oneconfig.internal.ui.components.rememberInteractionSource
@@ -134,6 +135,7 @@ internal fun <T> ListOptionContainer(
     showAddWhenFull: Boolean = false,
     entryHeight: Dp = ListEntryHeight,
     maxHeight: Dp = 280.dp,
+    containScroll: Boolean = false,
     invalid: (T) -> Boolean = { false },
     row: @Composable RowScope.(entry: ListRowEntry<T>, ctx: ListRowContext) -> Unit,
 ) {
@@ -176,11 +178,17 @@ internal fun <T> ListOptionContainer(
     ) {
         if (entries.isNotEmpty()) {
             val scrollState = rememberScrollState()
+            val containmentModifier = if (containScroll) {
+                Modifier.containVerticalScroll(scrollState)
+            } else {
+                Modifier
+            }
             Box(
                 modifier = Modifier
                     .fillMaxWidth()
                     .heightIn(max = maxHeight)
                     .fadingEdges(scrollState, theme.componentBackground)
+                    .then(containmentModifier)
                     .verticalScroll(scrollState),
             ) {
                 Box(


### PR DESCRIPTION
## What changed

- keep wheel and fling input inside scrollable item lists
- prevent the parent settings page from moving at the item list boundaries
- allow normal page scrolling when an item list has no internal overflow
- leave existing non-item list behavior unchanged

## Tested

- `:modules:internal:compileKotlin`
- `:modules:internal:j21Tests`
- manually tested on Fabric 1.21.4, 1.21.11 and 26.2

Closes #954