### PR TITLE
fix(hud): use window bounds for action bar

### DIFF
--- a/minecraft/src/main/kotlin/org/polyfrost/oneconfig/internal/ui/compose/impls/HudEditorUIScreen.kt
+++ b/minecraft/src/main/kotlin/org/polyfrost/oneconfig/internal/ui/compose/impls/HudEditorUIScreen.kt
@@ -110,7 +110,7 @@ class HudEditorUIScreen : ComposeScreen() {
             HudManager.guiScreenHeight = sh
             HudManager.prepare(sw, sh)
         }
-        HudEditorViewport.update(Platform.screen().viewportWidth(), Platform.screen().viewportHeight())
+        HudEditorViewport.update(Platform.screen().windowWidth(), Platform.screen().windowHeight())
         //~ if >= 26.1 'render' -> 'extractRenderState'
         super.extractRenderState(ctx, mouseX, mouseY, tickDelta)
     }

--- a/minecraft/src/main/kotlin/org/polyfrost/oneconfig/internal/ui/compose/impls/OneConfigUIScreen.kt
+++ b/minecraft/src/main/kotlin/org/polyfrost/oneconfig/internal/ui/compose/impls/OneConfigUIScreen.kt
@@ -267,7 +267,7 @@ class OneConfigUIScreen @JvmOverloads constructor(
             HudManager.guiScreenHeight = sh
             HudManager.prepare(sw, sh)
         }
-        HudEditorViewport.update(Platform.screen().viewportWidth(), Platform.screen().viewportHeight())
+        HudEditorViewport.update(Platform.screen().windowWidth(), Platform.screen().windowHeight())
         if (OneConfigConfig.enableBackgroundBlur) {
             //? if >= 1.21.10 {
             if (SkiaCtx.isDeferredComposeBackend) {

--- a/modules/internal/src/main/kotlin/org/polyfrost/oneconfig/internal/ui/hud/screens/HudDesignStudio.kt
+++ b/modules/internal/src/main/kotlin/org/polyfrost/oneconfig/internal/ui/hud/screens/HudDesignStudio.kt
@@ -127,22 +127,22 @@ enum class StudioCategory(val title: String, val icon: String) {
 }
 
 object HudEditorViewport {
-    var viewportWidth by mutableStateOf(0)
+    var screenWidth by mutableStateOf(0)
         private set
-    var viewportHeight by mutableStateOf(0)
+    var screenHeight by mutableStateOf(0)
         private set
 
     fun update(width: Int, height: Int) {
-        if (width == viewportWidth && height == viewportHeight) return
+        if (width == screenWidth && height == screenHeight) return
         Snapshot.withMutableSnapshot {
-            viewportWidth = width
-            viewportHeight = height
+            screenWidth = width
+            screenHeight = height
         }
     }
 
     fun observe() {
-        @Suppress("UNUSED_EXPRESSION") viewportWidth
-        @Suppress("UNUSED_EXPRESSION") viewportHeight
+        @Suppress("UNUSED_EXPRESSION") screenWidth
+        @Suppress("UNUSED_EXPRESSION") screenHeight
     }
 }
 
@@ -489,9 +489,9 @@ private fun hudActionBarLayout(
 
     // the bar lives outside the HUD box because small HUDs swallow or overlap the icons when the
     // buttons are laid out inside the bounds
-    val screenW = HudEditorViewport.viewportWidth.toFloat()
+    val screenW = HudEditorViewport.screenWidth.toFloat()
         .takeIf { it > 0f } ?: (HudManager.guiScreenWidth * mcToScreen)
-    val screenH = HudEditorViewport.viewportHeight.toFloat()
+    val screenH = HudEditorViewport.screenHeight.toFloat()
         .takeIf { it > 0f } ?: (HudManager.guiScreenHeight * mcToScreen)
 
     val padPx = actionBarPadding(gapPx)
@@ -972,7 +972,7 @@ fun HudDesignStudio(onReturnToOneConfig: (() -> Unit)? = null) {
         HudManager.pendingSelection = null
         HudManager.pendingAdd = null
         if (pendingAdd != null) {
-            snapshotFlow { HudEditorViewport.viewportWidth }.first { it > 0 }
+            snapshotFlow { HudEditorViewport.screenWidth }.first { it > 0 }
             val instance = placeHudCentered(pendingAdd)
             if (instance != null) {
                 Snapshot.withMutableSnapshot {


### PR DESCRIPTION
## Description

- The  hud action bar repositioning logic did not work on scaled displays
- Fixed by using window instead of framebuffer dimensions

Before (renders below screen)
<img width="340" height="265" alt="image" src="https://github.com/user-attachments/assets/113267bb-00a0-4b49-915d-7fb1235ee8cb" />

After:
<img width="396" height="252" alt="image" src="https://github.com/user-attachments/assets/08a6582c-ab52-4a6e-8540-aef3f3e697b0" />


## Checklist

- [x] I made a clear description of what was changed
- [x] I stated why these changes were necessary
- [x] I updated documentation or said what needs to be updated
- [x] I made sure these changes are backwards compatible
- [x] This pull request is for one feature/bug fix
