### PR TITLE
fix(ui): sync color picker chroma

### DIFF
--- a/modules/internal/src/main/kotlin/org/polyfrost/oneconfig/internal/ui/components/settings/ColorOption.kt
+++ b/modules/internal/src/main/kotlin/org/polyfrost/oneconfig/internal/ui/components/settings/ColorOption.kt
@@ -160,15 +160,12 @@ internal fun ChromaColorAnimation(
     model: ColorPickerModel,
     onColorChanged: (Color) -> Unit,
 ) {
-    LaunchedEffect(model.chromaEnabled, model.chromaSpeed) {
+    LaunchedEffect(model.chromaEnabled) {
         if (!model.chromaEnabled) return@LaunchedEffect
-        var lastNanos = withInfiniteAnimationFrameNanos { it }
         while (true) {
-            withInfiniteAnimationFrameNanos { frameNanos ->
-                val dt = (frameNanos - lastNanos) / 1_000_000_000f
-                lastNanos = frameNanos
-                model.hue = (model.hue + (360f / PolyColor.CHROMA_CYCLE_SECONDS.toFloat()) * model.chromaSpeed * dt) % 360f
-                onColorChanged(model.currentColor())
+            withInfiniteAnimationFrameNanos {
+                val baseColor = model.currentColor()
+                onColorChanged(Color(PolyColor(baseColor.toArgb(), true, model.chromaSpeed).argb))
             }
         }
     }
@@ -187,7 +184,7 @@ fun ColorOption(data: ColorOptionData) {
     val initialColor = remember(data.prop, initialValue) {
         when (val v = initialValue) {
             is Color -> v
-            is PolyColor -> Color(v.argb).let {
+            is PolyColor -> Color(v.rawArgb).let {
                 if (data.alpha) it else it.copy(alpha = 1f)
             }
 


### PR DESCRIPTION
## Description

- Use `PolyColor` chroma timing for the color preview ui instead of creating a separate animation

## Related Issue(s)

Fixes #708

## Checklist

- [x] I made a clear description of what was changed
- [x] I stated why these changes were necessary
- [x] I updated documentation or said what needs to be updated
- [x] I made sure these changes are backwards compatible
- [x] This pull request is for one feature/bug fix
