### PR TITLE
feat: uncap main menu FPS to refresh rate + 60

### DIFF
--- a/minecraft/src/main/java/org/polyfrost/oneconfig/internal/mixin/Mixin_MainMenuFpsUncap.java
+++ b/minecraft/src/main/java/org/polyfrost/oneconfig/internal/mixin/Mixin_MainMenuFpsUncap.java
@@ -21,24 +21,20 @@ public class Mixin_MainMenuFpsUncap {
 
     @Inject(method = "getFramerateLimit", at = @At("HEAD"), cancellable = true)
     private void oneconfig$uncapWhileSampling(CallbackInfoReturnable<Integer> cir) {
+        if (MainMenuFpsSampler.isSampling()) {
+            cir.setReturnValue(260);
+            return;
+        }
+
         Minecraft minecraft = Minecraft.getInstance();
         //? if >= 26.2 {
         Object screen = minecraft.gui.screen();
         //?} else
         //Object screen = minecraft.screen;
         if (minecraft.level == null && screen instanceof ComposeScreen) {
-            int fallback = FALLBACK_MONITOR_REFRESH_RATE + MAIN_MENU_FPS_HEADROOM;
             int refreshRate = minecraft.getWindow().getRefreshRate();
-            if (refreshRate > 0) {
-                cir.setReturnValue(refreshRate + MAIN_MENU_FPS_HEADROOM);
-            } else {
-                cir.setReturnValue(fallback);
-            }
-            return;
-        }
-
-        if (MainMenuFpsSampler.isSampling()) {
-            cir.setReturnValue(260);
+            if (refreshRate <= 0) refreshRate = FALLBACK_MONITOR_REFRESH_RATE;
+            cir.setReturnValue(refreshRate + MAIN_MENU_FPS_HEADROOM);
         }
     }
 }

--- a/minecraft/src/main/java/org/polyfrost/oneconfig/internal/mixin/Mixin_MainMenuFpsUncap.java
+++ b/minecraft/src/main/java/org/polyfrost/oneconfig/internal/mixin/Mixin_MainMenuFpsUncap.java
@@ -1,11 +1,10 @@
 package org.polyfrost.oneconfig.internal.mixin;
 
-//? if >=1.21.4 {
+//? if >= 1.21.4
 import com.mojang.blaze3d.platform.FramerateLimitTracker;
-//?} else {
-/*import net.minecraft.client.Minecraft;
-*///?}
+import net.minecraft.client.Minecraft;
 import org.polyfrost.oneconfig.internal.MainMenuFpsSampler;
+import org.polyfrost.oneconfig.internal.ui.compose.ComposeScreen;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
@@ -17,8 +16,27 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 /*@Mixin(value = Minecraft.class, priority = Integer.MAX_VALUE)
 *///?}
 public class Mixin_MainMenuFpsUncap {
+    private static final int MAIN_MENU_FPS_HEADROOM = 60;
+    private static final int FALLBACK_MONITOR_REFRESH_RATE = 60;
+
     @Inject(method = "getFramerateLimit", at = @At("HEAD"), cancellable = true)
     private void oneconfig$uncapWhileSampling(CallbackInfoReturnable<Integer> cir) {
+        Minecraft minecraft = Minecraft.getInstance();
+        //? if >= 26.2 {
+        Object screen = minecraft.gui.screen();
+        //?} else
+        //Object screen = minecraft.screen;
+        if (minecraft.level == null && screen instanceof ComposeScreen) {
+            int fallback = FALLBACK_MONITOR_REFRESH_RATE + MAIN_MENU_FPS_HEADROOM;
+            int refreshRate = minecraft.getWindow().getRefreshRate();
+            if (refreshRate > 0) {
+                cir.setReturnValue(refreshRate + MAIN_MENU_FPS_HEADROOM);
+            } else {
+                cir.setReturnValue(fallback);
+            }
+            return;
+        }
+
         if (MainMenuFpsSampler.isSampling()) {
             cir.setReturnValue(260);
         }


### PR DESCRIPTION
## Description
- When OneConfig is open in main menu, it uncaps FPS to refresh rate + 60 matching PolyPlus behaviour

## Checklist

- [x] I made a clear description of what was changed
- [x] I stated why these changes were necessary
- [x]  I updated documentation or said what needs to be updated
- [x] I made sure these changes are backwards compatible
- [x] This pull request is for one feature/bug fix
