### PR TITLE
fix: allow opening from title screen in dev

### DIFF
--- a/minecraft/src/main/java/org/polyfrost/oneconfig/internal/OneConfig.java
+++ b/minecraft/src/main/java/org/polyfrost/oneconfig/internal/OneConfig.java
@@ -33,6 +33,7 @@ import net.minecraft.ChatFormatting;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.GuiGraphicsExtractor;
 import net.minecraft.client.gui.screens.ChatScreen;
+import net.minecraft.client.gui.screens.TitleScreen;
 import net.minecraft.network.chat.Component;
 import net.minecraft.world.scores.DisplaySlot;
 import net.minecraft.world.scores.Scoreboard;
@@ -118,7 +119,8 @@ public class OneConfig
             if (OneConfigConfig.consumeKeybindClose()) {
                 return true;
             }
-            if (Platform.screen().current() != null) {
+            Object screen = Platform.screen().current();
+            if (screen != null && !(Platform.compatibility().isDevelopment() && screen instanceof TitleScreen)) {
                 return true;
             }
             if (Minecraft.getInstance().level == null && !Platform.compatibility().isDevelopment()) {


### PR DESCRIPTION
## Description
- Allows opening OneConfig in title screen in development as originally intended
- No non-dev functional changes

## Related Issue(s)

<!-- List the issue(s) this PR solves -->

## Checklist

- [x] I made a clear description of what was changed
- [x] I stated why these changes were necessary
- [x] I updated documentation or said what needs to be updated
- [x] I made sure these changes are backwards compatible
- [x] This pull request is for one feature/bug fix
