### PR TITLE
fix(ui): open non-animated pages immediately

### DIFF
--- a/modules/internal/src/main/kotlin/org/polyfrost/oneconfig/internal/ui/OneConfigInterface.kt
+++ b/modules/internal/src/main/kotlin/org/polyfrost/oneconfig/internal/ui/OneConfigInterface.kt
@@ -39,6 +39,7 @@ import androidx.compose.ui.unit.Density
 import androidx.lifecycle.compose.LocalLifecycleOwner
 import androidx.lifecycle.viewmodel.compose.LocalViewModelStoreOwner
 import androidx.navigation.compose.rememberNavController
+import kotlinx.coroutines.flow.first
 import org.apache.logging.log4j.LogManager
 import org.polyfrost.oneconfig.internal.OneConfigConfig
 import org.polyfrost.oneconfig.internal.ui.hud.screens.HudDragLayer
@@ -91,10 +92,12 @@ fun OneConfigInterface(
             // the page is only being put back which should look like it was never left
             ShellState.initialTransitionConsumed = false
             ShellState.animateOpeningPage = !restoring && OneConfigConfig.showOpeningPageAnimation
+            // non-animated opens navigate instantly when the graph is ready
+            if (!ShellState.animateOpeningPage) LocalNavController.current.currentBackStackEntryFlow.first()
             // the NavHost only sets its graph once the Shell is composed so wait for it or navigate()
             // crashes with "must call setGraph() before getGraph()"
             var attempts = 0
-            while (attempts++ < 600) {
+            while (ShellState.animateOpeningPage && attempts++ < 600) {
                 val ready = try {
                     LocalNavController.current.graph; true
                 } catch (_: IllegalStateException) {

--- a/modules/internal/src/main/kotlin/org/polyfrost/oneconfig/internal/ui/OneConfigInterface.kt
+++ b/modules/internal/src/main/kotlin/org/polyfrost/oneconfig/internal/ui/OneConfigInterface.kt
@@ -40,6 +40,7 @@ import androidx.lifecycle.compose.LocalLifecycleOwner
 import androidx.lifecycle.viewmodel.compose.LocalViewModelStoreOwner
 import androidx.navigation.compose.rememberNavController
 import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.withTimeoutOrNull
 import org.apache.logging.log4j.LogManager
 import org.polyfrost.oneconfig.internal.OneConfigConfig
 import org.polyfrost.oneconfig.internal.ui.hud.screens.HudDragLayer
@@ -60,6 +61,8 @@ fun guiCloseAnimationMillis(): Long =
     else (OneConfigConfig.animationTime * 1000f).toLong().coerceIn(1L, MAX_CLOSE_ANIMATION_MS)
 
 private const val MAX_CLOSE_ANIMATION_MS = 160L
+
+private const val GRAPH_WAIT_TIMEOUT_MS = 10_000L
 
 @Composable
 fun OneConfigInterface(
@@ -92,19 +95,23 @@ fun OneConfigInterface(
             // the page is only being put back which should look like it was never left
             ShellState.initialTransitionConsumed = false
             ShellState.animateOpeningPage = !restoring && OneConfigConfig.showOpeningPageAnimation
-            // non-animated opens navigate instantly when the graph is ready
-            if (!ShellState.animateOpeningPage) LocalNavController.current.currentBackStackEntryFlow.first()
             // the NavHost only sets its graph once the Shell is composed so wait for it or navigate()
             // crashes with "must call setGraph() before getGraph()"
-            var attempts = 0
-            while (ShellState.animateOpeningPage && attempts++ < 600) {
-                val ready = try {
-                    LocalNavController.current.graph; true
-                } catch (_: IllegalStateException) {
-                    false
+            if (ShellState.animateOpeningPage) {
+                var attempts = 0
+                while (attempts++ < 600) {
+                    val ready = try {
+                        LocalNavController.current.graph; true
+                    } catch (_: IllegalStateException) {
+                        false
+                    }
+                    if (ready) break
+                    withFrameNanos { }
                 }
-                if (ready) break
-                withFrameNanos { }
+            } else {
+                withTimeoutOrNull(GRAPH_WAIT_TIMEOUT_MS) {
+                    LocalNavController.current.currentBackStackEntryFlow.first()
+                }
             }
             try {
                 LocalNavController.wrapper.navigate(initialRoute, clearSearch = !resuming)


### PR DESCRIPTION
## Description
The mods page flashed briefly when reopening Oneconfig on a previously visited page when opening animations is disabled, see the vid below.

If opening animations is diabled, it now waits for `currentBackStackEntryFlow.first()`, then navigates immediately, so the correct route appears in the first frame

Before:

https://github.com/user-attachments/assets/4bcafa5f-f3ac-4db4-a1ad-a80e35f6a52d

After:

https://github.com/user-attachments/assets/59727721-5d55-45ea-a19a-f5d6178a93b3


## Checklist

- [x] I made a clear description of what was changed
- [x] I stated why these changes were necessary
- [x] I updated documentation or said what needs to be updated
- [x] I made sure these changes are backwards compatible
- [x] This pull request is for one feature/bug fix
