### PR TITLE
fix(events): correct TickEvent injection target

### DIFF
--- a/minecraft/src/main/java/org/polyfrost/oneconfig/api/platform/v1/internal/ScreenPlatformImpl.java
+++ b/minecraft/src/main/java/org/polyfrost/oneconfig/api/platform/v1/internal/ScreenPlatformImpl.java
@@ -32,6 +32,7 @@ import net.minecraft.client.gui.screens.Screen;
 import net.minecraft.network.chat.Component;
 import org.jetbrains.annotations.Nullable;
 import org.polyfrost.oneconfig.api.event.v1.EventDelay;
+import org.polyfrost.oneconfig.api.event.v1.events.FramebufferRenderEvent;
 import org.polyfrost.oneconfig.api.platform.v1.ScreenPlatform;
 import org.polyfrost.oneconfig.internal.ui.compose.ComposeScreen;
 import org.polyfrost.oneconfig.internal.ui.compose.ComposeSupport;
@@ -86,7 +87,7 @@ public class ScreenPlatformImpl implements ScreenPlatform {
     }
 
     @Override
-    public void display(@Nullable Object screen, int ticks) {
+    public void display(@Nullable Object screen, int frames) {
         if (screen instanceof ComposeScreen) {
             String unavailable = ComposeSupport.INSTANCE.unavailableReason();
             if (unavailable != null) {
@@ -99,17 +100,17 @@ public class ScreenPlatformImpl implements ScreenPlatform {
             }
         }
         if (!Minecraft.getInstance().isSameThread()) {
-            Minecraft.getInstance().schedule(() -> display(screen, ticks));
+            Minecraft.getInstance().schedule(() -> display(screen, frames));
             return;
         }
         //? if >= 26.2 {
         // 26.2 removed Minecraft#setScreen so use Gui#setScreen not setScreenAndShow which force-calls
         // renderFrame and re-enters our renderFrame mixin giving a nested frame and a black flash
-        if (ticks < 1) Minecraft.getInstance().gui.setScreen((Screen) screen);
-        else EventDelay.tick(ticks, () -> Minecraft.getInstance().gui.setScreen((Screen) screen));
+        if (frames < 1) Minecraft.getInstance().gui.setScreen((Screen) screen);
+        else EventDelay.of(FramebufferRenderEvent.End.class, frames, () -> Minecraft.getInstance().gui.setScreen((Screen) screen));
         //?} else {
-        /*if (ticks < 1) Minecraft.getInstance().setScreen((Screen) screen);
-        else EventDelay.tick(ticks, () -> Minecraft.getInstance().setScreen((Screen) screen));
+        /*if (frames < 1) Minecraft.getInstance().setScreen((Screen) screen);
+        else EventDelay.of(FramebufferRenderEvent.End.class, frames, () -> Minecraft.getInstance().setScreen((Screen) screen));
         *///?}
     }
 

--- a/minecraft/src/main/java/org/polyfrost/oneconfig/internal/MainMenuFpsSampler.java
+++ b/minecraft/src/main/java/org/polyfrost/oneconfig/internal/MainMenuFpsSampler.java
@@ -30,8 +30,8 @@ import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.screens.LevelLoadingScreen;
 import net.minecraft.client.gui.screens.TitleScreen;
 import org.polyfrost.oneconfig.api.event.v1.EventManager;
+import org.polyfrost.oneconfig.api.event.v1.events.FramebufferRenderEvent;
 import org.polyfrost.oneconfig.api.event.v1.events.MainMenuFpsEvent;
-import org.polyfrost.oneconfig.api.event.v1.events.TickEvent;
 import org.polyfrost.oneconfig.api.event.v1.invoke.EventHandler;
 import org.polyfrost.oneconfig.api.platform.v1.Platform;
 import org.polyfrost.oneconfig.internal.ui.compose.ComposeScreen;
@@ -58,7 +58,7 @@ public final class MainMenuFpsSampler {
 
     public static void init() {
         MainMenuFpsSampler sampler = new MainMenuFpsSampler();
-        EventHandler.ofRemoving(TickEvent.End.class, e -> sampler.tick()).register();
+        EventHandler.ofRemoving(FramebufferRenderEvent.End.class, e -> sampler.tick()).register();
     }
 
     private boolean tick() {

--- a/minecraft/src/main/java/org/polyfrost/oneconfig/internal/mixin/events/Mixin_TickEvent.java
+++ b/minecraft/src/main/java/org/polyfrost/oneconfig/internal/mixin/events/Mixin_TickEvent.java
@@ -11,12 +11,12 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 @Mixin(Minecraft.class)
 public class Mixin_TickEvent {
 
-    @Inject(method = "runTick", at = @At(value = "INVOKE", target = "Lnet/minecraft/util/profiling/ProfilerFiller;push(Ljava/lang/String;)V", ordinal = 0))
+    @Inject(method = "tick", at = @At("HEAD"))
     private void tickStartCallback(CallbackInfo ci) {
         EventManager.INSTANCE.post(TickEvent.Start.INSTANCE);
     }
 
-    @Inject(method = "runTick", at = @At("TAIL"))
+    @Inject(method = "tick", at = @At("TAIL"))
     private void tickEndCallback(CallbackInfo ci) {
         EventManager.INSTANCE.post(TickEvent.End.INSTANCE);
     }

--- a/minecraft/src/main/kotlin/org/polyfrost/oneconfig/internal/compat/YACLCompat.kt
+++ b/minecraft/src/main/kotlin/org/polyfrost/oneconfig/internal/compat/YACLCompat.kt
@@ -11,6 +11,7 @@ import org.polyfrost.oneconfig.api.config.v1.dsl.noCache
 import org.polyfrost.oneconfig.api.config.v1.dsl.saveFunction
 import org.polyfrost.oneconfig.api.config.v1.dsl.subcategory
 import org.polyfrost.oneconfig.api.event.v1.EventDelay
+import org.polyfrost.oneconfig.api.event.v1.events.FramebufferRenderEvent
 import org.polyfrost.oneconfig.api.platform.v1.ModInfo
 import org.polyfrost.oneconfig.api.platform.v1.Platform
 import org.polyfrost.oneconfig.internal.compat.CompatIds.componentKey
@@ -58,14 +59,14 @@ object YACLCompat {
 
         private fun awaitSettle() {
             val stamp = writeStamp
-            EventDelay.tick(FLAG_SETTLE_FRAMES) {
+            EventDelay.of(FramebufferRenderEvent.End::class.java, FLAG_SETTLE_FRAMES, Runnable {
                 if (writeStamp != stamp) {
                     awaitSettle()
                 } else {
                     drainScheduled = false
                     runPendingFlags()
                 }
-            }
+            })
         }
 
         fun runPendingFlags() {

--- a/minecraft/src/main/kotlin/org/polyfrost/oneconfig/utils/v1/dsl/screens.kt
+++ b/minecraft/src/main/kotlin/org/polyfrost/oneconfig/utils/v1/dsl/screens.kt
@@ -37,7 +37,7 @@ import org.polyfrost.oneconfig.internal.ui.api.ConfigRegistry
 import org.polyfrost.oneconfig.internal.ui.api.ConfigSource
 import org.polyfrost.oneconfig.internal.ui.compose.impls.OneConfigUIScreen
 
-fun Screen.openScreen(ticks: Int = 1) = Platform.screen().display(this, ticks)
+fun Screen.openScreen(frames: Int = 1) = Platform.screen().display(this, frames)
 
 fun Tree.createScreen(): Screen {
     val treeId = id

--- a/modules/events/src/main/java/org/polyfrost/oneconfig/api/event/v1/EventDelay.java
+++ b/modules/events/src/main/java/org/polyfrost/oneconfig/api/event/v1/EventDelay.java
@@ -52,11 +52,9 @@ public final class EventDelay {
 
                 @Override
                 public boolean handle(E event) {
-                    if (delay < 1) {
+                    if (--delay < 1) {
                         function.accept(event);
                         return true;
-                    } else {
-                        delay--;
                     }
                     return false;
                 }

--- a/modules/utils/src/main/java/org/polyfrost/oneconfig/api/platform/v1/ScreenPlatform.java
+++ b/modules/utils/src/main/java/org/polyfrost/oneconfig/api/platform/v1/ScreenPlatform.java
@@ -82,7 +82,7 @@ public interface ScreenPlatform {
     default void showMessage(String message) {
     }
 
-    void display(@Nullable Object screen, int ticks);
+    void display(@Nullable Object screen, int frames);
 
     default void display(Object screen) {
         display(screen, 1);


### PR DESCRIPTION
## Description
- Fixed `EventDelay` off by one
- Fixed wrong TickEvent injection target

Moved intentional frame dependent behavior in OneConfig to use `FramebufferRenderEvent`, now nothing in Oneconfig uses `TickEvent`:
- Deferred screen opening
- Main menu fps sampling
- YACL compatibility flag settling

## Checklist

- [x] I made a clear description of what was changed
- [x] I stated why these changes were necessary
- [x] I updated documentation or said what needs to be updated
- [x] I made sure these changes are backwards compatible
- [x] This pull request is for one feature/bug fix
