### PR TITLE
chore: minor fixes and cleanup

### DIFF
--- a/bootstrap/src/main/resources/fabric.mod.json
+++ b/bootstrap/src/main/resources/fabric.mod.json
@@ -22,7 +22,6 @@
     "fabricloader": ">=0.12.0",
     "minecraft": "${mc_version}",
     "compose-multiplatform": "*",
-    "fabric-language-kotlin": ">=1.13.8+kotlin.2.3.0",
-    "fabric-api": "*"
+    "fabric-language-kotlin": ">=1.13.8+kotlin.2.3.0"
   }
 }

--- a/minecraft/src/main/java/org/polyfrost/oneconfig/internal/mixin/events/Mixin_ChatReceiveEvent.java
+++ b/minecraft/src/main/java/org/polyfrost/oneconfig/internal/mixin/events/Mixin_ChatReceiveEvent.java
@@ -29,41 +29,31 @@ public abstract class Mixin_ChatReceiveEvent {
     @Unique private Component ocfg$nativeMessage;
     @Unique private net.kyori.adventure.text.Component ocfg$postedMessage;
 
-    //? if >= 26.1 {
     @Inject(
+            //? if >= 26.1 {
             method = "addMessage(Lnet/minecraft/network/chat/Component;Lnet/minecraft/network/chat/MessageSignature;Lnet/minecraft/client/multiplayer/chat/GuiMessageSource;Lnet/minecraft/client/multiplayer/chat/GuiMessageTag;)V",
+            //?} else {
+            /*method = "addMessage(Lnet/minecraft/network/chat/Component;Lnet/minecraft/network/chat/MessageSignature;Lnet/minecraft/client/GuiMessageTag;)V",
+            *///?}
             at = @At("HEAD"),
             cancellable = true
     )
+    //? if >= 26.1 {
     public void chatReceiveCallback(Component message, MessageSignature signature, GuiMessageSource source, GuiMessageTag tag, CallbackInfo ci) {
-        if (ocfg$post(message)) {
-            ci.cancel();
-        }
-    }
-
-    @ModifyVariable(
-            method = "addMessage(Lnet/minecraft/network/chat/Component;Lnet/minecraft/network/chat/MessageSignature;Lnet/minecraft/client/multiplayer/chat/GuiMessageSource;Lnet/minecraft/client/multiplayer/chat/GuiMessageTag;)V",
-            at = @At("HEAD"),
-            ordinal = 0,
-            argsOnly = true
-    )
-    public Component modifyMessage(Component message) {
-        return ocfg$consume(message);
-    }
     //?} else {
-    /*@Inject(
-            method = "addMessage(Lnet/minecraft/network/chat/Component;Lnet/minecraft/network/chat/MessageSignature;Lnet/minecraft/client/GuiMessageTag;)V",
-            at = @At("HEAD"),
-            cancellable = true
-    )
-    public void chatReceiveCallback(Component message, MessageSignature signature, GuiMessageTag tag, CallbackInfo ci) {
+    /*public void chatReceiveCallback(Component message, MessageSignature signature, GuiMessageTag tag, CallbackInfo ci) {
+    *///?}
         if (ocfg$post(message)) {
             ci.cancel();
         }
     }
 
     @ModifyVariable(
-            method = "addMessage(Lnet/minecraft/network/chat/Component;Lnet/minecraft/network/chat/MessageSignature;Lnet/minecraft/client/GuiMessageTag;)V",
+            //? if >= 26.1 {
+            method = "addMessage(Lnet/minecraft/network/chat/Component;Lnet/minecraft/network/chat/MessageSignature;Lnet/minecraft/client/multiplayer/chat/GuiMessageSource;Lnet/minecraft/client/multiplayer/chat/GuiMessageTag;)V",
+            //?} else {
+            /*method = "addMessage(Lnet/minecraft/network/chat/Component;Lnet/minecraft/network/chat/MessageSignature;Lnet/minecraft/client/GuiMessageTag;)V",
+            *///?}
             at = @At("HEAD"),
             ordinal = 0,
             argsOnly = true
@@ -71,7 +61,6 @@ public abstract class Mixin_ChatReceiveEvent {
     public Component modifyMessage(Component message) {
         return ocfg$consume(message);
     }
-    *///?}
 
     @Unique
     private boolean ocfg$post(Component message) {

--- a/minecraft/src/main/java/org/polyfrost/oneconfig/internal/mixin/events/Mixin_HudRenderEvent.java
+++ b/minecraft/src/main/java/org/polyfrost/oneconfig/internal/mixin/events/Mixin_HudRenderEvent.java
@@ -16,7 +16,7 @@ import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
 //? if >= 26.2 {
- @Mixin(Hud.class)
+@Mixin(Hud.class)
 //? } else {
 /*@Mixin(Gui.class)
 *///? }

--- a/minecraft/src/main/java/org/polyfrost/oneconfig/internal/mixin/events/Mixin_KeyInputEvent.java
+++ b/minecraft/src/main/java/org/polyfrost/oneconfig/internal/mixin/events/Mixin_KeyInputEvent.java
@@ -11,6 +11,7 @@ import org.polyfrost.oneconfig.api.platform.v1.Platform;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
+//? if >= 1.21.10
 import org.spongepowered.asm.mixin.injection.ModifyVariable;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 

--- a/minecraft/src/main/java/org/polyfrost/oneconfig/internal/mixin/events/Mixin_RenderLivingEntityEvent.java
+++ b/minecraft/src/main/java/org/polyfrost/oneconfig/internal/mixin/events/Mixin_RenderLivingEntityEvent.java
@@ -2,11 +2,11 @@ package org.polyfrost.oneconfig.internal.mixin.events;
 
 import com.mojang.blaze3d.vertex.PoseStack;
 import net.minecraft.client.Minecraft;
-//? < 26.2 {
-/*import net.minecraft.client.renderer.MultiBufferSource;
-*///? }
+//? if < 1.21.9
+//import net.minecraft.client.renderer.MultiBufferSource;
 import net.minecraft.client.renderer.entity.LivingEntityRenderer;
-import net.minecraft.world.entity.LivingEntity;
+//? if < 1.21.2
+//import net.minecraft.world.entity.LivingEntity;
 import org.polyfrost.oneconfig.api.event.v1.EventManager;
 import org.polyfrost.oneconfig.api.event.v1.events.RenderLivingEvent;
 import org.spongepowered.asm.mixin.Mixin;
@@ -21,15 +21,9 @@ import net.minecraft.client.renderer.state.level.CameraRenderState;
 //? }
 //? if >= 1.21.2
 import net.minecraft.client.renderer.entity.state.LivingEntityRenderState;
-//? if < 1.21.2
-//import net.minecraft.client.Minecraft;
 
 @Mixin(LivingEntityRenderer.class)
-public class Mixin_RenderLivingEntityEvent<
-        T extends LivingEntity
-        //? >= 1.21.2
-        , S extends LivingEntityRenderState
-        > {
+public class Mixin_RenderLivingEntityEvent {
     @Inject(
             //? >= 1.21.9 {
             //~ if >= 26.1 'state/Camera' -> 'state/level/Camera'
@@ -41,26 +35,13 @@ public class Mixin_RenderLivingEntityEvent<
             at = @At("HEAD"),
             cancellable = true
     )
-    private void onPreEntityRenderCallback(
-            //? >= 1.21.2 {
-            S entity,
-            //? } else
-            //T entity,
-            //? <= 1.21.1 {
-            /*float entityYaw,
-            float partialTicks,
-            *///? }
-            //? >= 1.21.9 {
-            PoseStack matrixStack,
-            SubmitNodeCollector renderQueue,
-            CameraRenderState cameraState,
-            //? } else {
-            /*PoseStack matrixStack,
-            MultiBufferSource buffer,
-            int packedLight,
-            *///? }
-            CallbackInfo ci
-    ) {
+    //? if >= 1.21.9 {
+    private void onPreEntityRenderCallback(LivingEntityRenderState entity, PoseStack matrixStack, SubmitNodeCollector renderQueue, CameraRenderState cameraState, CallbackInfo ci) {
+    //?} elif >= 1.21.2 {
+    /*private void onPreEntityRenderCallback(LivingEntityRenderState entity, PoseStack matrixStack, MultiBufferSource buffer, int packedLight, CallbackInfo ci) {
+    *///?} else {
+    /*private void onPreEntityRenderCallback(LivingEntity entity, float entityYaw, float partialTicks, PoseStack matrixStack, MultiBufferSource buffer, int packedLight, CallbackInfo ci) {
+    *///?}
 
         //? >= 1.21.2 {
         double x = entity.x;
@@ -89,26 +70,13 @@ public class Mixin_RenderLivingEntityEvent<
             //method = "render(Lnet/minecraft/world/entity/LivingEntity;FFLcom/mojang/blaze3d/vertex/PoseStack;Lnet/minecraft/client/renderer/MultiBufferSource;I)V",
             at = @At("TAIL")
     )
-    private void onPostEntityRenderCallback(
-            //? >= 1.21.2 {
-            S entity,
-            //? } else
-            //T entity,
-            //? <= 1.21.1 {
-            /*float entityYaw,
-            float partialTicks,
-            *///? }
-            //? >= 1.21.9 {
-            PoseStack matrixStack,
-            SubmitNodeCollector renderQueue,
-            CameraRenderState cameraState,
-            //? } else {
-            /*PoseStack matrixStack,
-            MultiBufferSource buffer,
-            int packedLight,
-            *///? }
-            CallbackInfo ci
-    ) {
+    //? if >= 1.21.9 {
+    private void onPostEntityRenderCallback(LivingEntityRenderState entity, PoseStack matrixStack, SubmitNodeCollector renderQueue, CameraRenderState cameraState, CallbackInfo ci) {
+    //?} elif >= 1.21.2 {
+    /*private void onPostEntityRenderCallback(LivingEntityRenderState entity, PoseStack matrixStack, MultiBufferSource buffer, int packedLight, CallbackInfo ci) {
+    *///?} else {
+    /*private void onPostEntityRenderCallback(LivingEntity entity, float entityYaw, float partialTicks, PoseStack matrixStack, MultiBufferSource buffer, int packedLight, CallbackInfo ci) {
+    *///?}
         //? >= 1.21.2 {
         double x = entity.x;
         double y = entity.y;

--- a/minecraft/src/main/java/org/polyfrost/oneconfig/internal/mixin/events/Mixin_SoundPlayedEvent.java
+++ b/minecraft/src/main/java/org/polyfrost/oneconfig/internal/mixin/events/Mixin_SoundPlayedEvent.java
@@ -20,6 +20,7 @@ public class Mixin_SoundPlayedEvent {
             String name = value.getSound().getLocation().toString();
             SoundPlayedEvent event = new SoundPlayedEvent(name, null, value);
             EventManager.INSTANCE.post(event);
+            return event.getSound();
         }
 
         return value;

--- a/minecraft/src/main/java/org/polyfrost/oneconfig/internal/mixin/events/Mixin_SoundPlayedEvent.java
+++ b/minecraft/src/main/java/org/polyfrost/oneconfig/internal/mixin/events/Mixin_SoundPlayedEvent.java
@@ -20,7 +20,11 @@ public class Mixin_SoundPlayedEvent {
             String name = value.getSound().getLocation().toString();
             SoundPlayedEvent event = new SoundPlayedEvent(name, null, value);
             EventManager.INSTANCE.post(event);
-            return event.getSound();
+
+            Object modified = event.getSound();
+            if (modified instanceof SoundInstance) {
+                return (SoundInstance) modified;
+            }
         }
 
         return value;

--- a/minecraft/src/main/java/org/polyfrost/oneconfig/internal/mixin/skia/Mixin_InitSkiaFontRenderer.java
+++ b/minecraft/src/main/java/org/polyfrost/oneconfig/internal/mixin/skia/Mixin_InitSkiaFontRenderer.java
@@ -1,11 +1,8 @@
 package org.polyfrost.oneconfig.internal.mixin.skia;
 
-import com.mojang.blaze3d.platform.Window;
 import net.minecraft.client.Minecraft;
-import org.polyfrost.oneconfig.internal.ui.compose.SkiaCtx;
 import org.polyfrost.oneconfig.internal.ui.compose.SkiaFontRenderer;
 import org.spongepowered.asm.mixin.Mixin;
-import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;

--- a/minecraft/src/main/java/org/polyfrost/oneconfig/internal/mixin/skia/Mixin_SkiaFrame.java
+++ b/minecraft/src/main/java/org/polyfrost/oneconfig/internal/mixin/skia/Mixin_SkiaFrame.java
@@ -21,16 +21,12 @@ public class Mixin_SkiaFrame {
         SkiaCtx.INSTANCE.recreateSurface(this.framebufferWidth, this.framebufferHeight);
     }
 
-    //? if >= 26.1 {
-    //? } else if >= 1.21.4 {
-    /*@Inject(method = "updateDisplay(Lcom/mojang/blaze3d/TracyFrameCapture;)V", at = @At("HEAD"))
-    void impl$onDraw(CallbackInfo ci) {
-        if (!SkiaCtx.INSTANCE.isVulkanMode()) {
-            SkiaCtx.INSTANCE.draw();
-        }
-    }
-    *///? } else {
-    /*@Inject(method = "updateDisplay()V", at = @At("HEAD"))
+    //? if < 26.1 {
+    /*//? if >= 1.21.4 {
+    @Inject(method = "updateDisplay(Lcom/mojang/blaze3d/TracyFrameCapture;)V", at = @At("HEAD"))
+    //?} else {
+    /^@Inject(method = "updateDisplay()V", at = @At("HEAD"))
+    ^///?}
     void impl$onDraw(CallbackInfo ci) {
         if (!SkiaCtx.INSTANCE.isVulkanMode()) {
             SkiaCtx.INSTANCE.draw();

--- a/minecraft/src/main/kotlin/org/polyfrost/oneconfig/internal/ui/services/GLInterfaceFactory.kt
+++ b/minecraft/src/main/kotlin/org/polyfrost/oneconfig/internal/ui/services/GLInterfaceFactory.kt
@@ -82,7 +82,9 @@ internal object GLInterfaceFactory {
                 LibFFI.ffi_type_pointer,
                 LibFFI.ffi_type_pointer,
             )
-            //? if >=26.1
+            //? if >= 26.3 {
+            /*private val DESCRIPTOR: Callback.Descriptor = Callback.Descriptor(GetProcCallbackI::class.java, MethodHandles.lookup(), CALL_INTERFACE)
+            *///?} elif >= 26.1
             private val DESCRIPTOR: Callback.Descriptor = Callback.Descriptor(MethodHandles.lookup(), CALL_INTERFACE)
         }
     }

--- a/minecraft/src/main/resources/fabric.mod.json
+++ b/minecraft/src/main/resources/fabric.mod.json
@@ -34,7 +34,8 @@
   },
   "depends": {
     "fabricloader": ">=0.12.0",
-    "minecraft": "${fabric_mc_version}"
+    "minecraft": "${fabric_mc_version}",
+    "fabric-api": "*"
   },
   "custom": {
     "modmenu": {


### PR DESCRIPTION
## Description
More cleanup to make ornithe port easier

The only functional change is a fix to `Mixin_SoundPlayedEvent` which was ported wrongly in https://github.com/Polyfrost/OneConfig/commit/89dbc43c. The `ModifyVariable` mixin should return the modified sound, previously the original sound was always played.

- legacy-lwjgl3 uses newer LWJGL 3.4.2, which MC 26.3 will also use. Added a `>= 26.3` condition for its updated callback descriptor https://github.com/LWJGL/lwjgl3/commit/e28dd69476e16201ee17053df99ce9d20fcddb7d
- Moved `fabric-api` dependency in `fabric.mod.json` from the bootstrap module to the minecraft module, so the bootstrap one is modloader independent. Dependency resolution is transitive so this is fine
- The rest are stonecutter improvements and import cleanups

## Related Issue(s)

<!-- List the issue(s) this PR solves -->

## Checklist

- [x] I made a clear description of what was changed
- [x] I stated why these changes were necessary
- [x] I updated documentation or said what needs to be updated
- [x] I made sure these changes are backwards compatible
- [x] This pull request is for one feature/bug fix
