### PR TITLE
fix: keybinds scrollbar padding

### DIFF
--- a/modules/internal/src/main/kotlin/org/polyfrost/oneconfig/internal/ui/screens/Keybinds.kt
+++ b/modules/internal/src/main/kotlin/org/polyfrost/oneconfig/internal/ui/screens/Keybinds.kt
@@ -120,7 +120,7 @@ fun Keybinds() {
     Box(Modifier.fillMaxSize()) {
         LazyColumn(
             state = listState,
-            modifier = Modifier.fillMaxSize().padding(end = 10.dp),
+            modifier = Modifier.fillMaxSize().padding(end = 16.dp),
             verticalArrangement = Arrangement.spacedBy(12.dp),
         ) {
             visibleGroups.forEach { group ->


### PR DESCRIPTION
## Description
- Everything else uses 16.dp except keybinds

## Checklist

- [x] I made a clear description of what was changed
- [x] I stated why these changes were necessary
- [x] I updated documentation or said what needs to be updated
- [x] I made sure these changes are backwards compatible
- [x] This pull request is for one feature/bug fix
