### PR TITLE
fix: title screen panorama rendering in < 1.21.8

### DIFF
--- a/minecraft/src/main/kotlin/org/polyfrost/oneconfig/internal/ui/compose/ComposeScreen.kt
+++ b/minecraft/src/main/kotlin/org/polyfrost/oneconfig/internal/ui/compose/ComposeScreen.kt
@@ -354,6 +354,10 @@ abstract class ComposeScreen(
     //~ if >= 26.1 'render' -> 'extractRenderState'
     override fun extractRenderState(ctx: GuiGraphicsExtractor, mouseX: Int, mouseY: Int, tickDelta: Float) {
         if (Platform.screen().current<Any?>() !== this) return
+
+        //? if < 1.21.8
+        //renderBackground(ctx, mouseX, mouseY, tickDelta)
+
         if (scenePoisoned) {
             if (sceneRebuilds >= MAX_SCENE_REBUILDS) {
                 LOGGER.error(

--- a/minecraft/src/main/kotlin/org/polyfrost/oneconfig/internal/ui/compose/impls/HudEditorUIScreen.kt
+++ b/minecraft/src/main/kotlin/org/polyfrost/oneconfig/internal/ui/compose/impls/HudEditorUIScreen.kt
@@ -99,6 +99,8 @@ class HudEditorUIScreen : ComposeScreen() {
         // a screen drawn over this one may render it as its parent so skip that pass or it closes the screen above us
         if (Platform.screen().current<Any?>() !== this) return
         if (closeRequested && System.currentTimeMillis() - closeRequestedAt >= closeAnimationMs) {
+            //? if < 1.21.8
+            //renderBackground(ctx, mouseX, mouseY, tickDelta)
             Platform.screen().close()
             return
         }

--- a/minecraft/src/main/kotlin/org/polyfrost/oneconfig/internal/ui/compose/impls/OneConfigUIScreen.kt
+++ b/minecraft/src/main/kotlin/org/polyfrost/oneconfig/internal/ui/compose/impls/OneConfigUIScreen.kt
@@ -264,6 +264,8 @@ class OneConfigUIScreen @JvmOverloads constructor(
         // and that would queue a fullscreen blur which smears over the popup so bail unless we are current
         if (Platform.screen().current<Any?>() !== this) return
         if (closeRequested && System.currentTimeMillis() - closeRequestedAt >= closeAnimationMs) {
+            //? if < 1.21.8
+            //renderBackground(ctx, mouseX, mouseY, tickDelta)
             Platform.screen().close()
             //? if >= 1.21.8 {
             // This frame skipped normal HUD rendering because OneConfig was open.


### PR DESCRIPTION
## Description

Fixes frozen (1.21.1, 1.21.4) or black (1.21.5) title screen panoramas in Oneconfig screens by restoring the `renderBackground` call skipped by the overrides

## Checklist

- [x] I made a clear description of what was changed
- [x] I stated why these changes were necessary
- [x] I updated documentation or said what needs to be updated
- [x] I made sure these changes are backwards compatible
- [x] This pull request is for one feature/bug fix
