### PR TITLE
fix(ui): position dropdowns on side with more space

### DIFF
--- a/modules/internal/src/main/kotlin/org/polyfrost/oneconfig/internal/ui/components/dropdown/DropdownMenu.kt
+++ b/modules/internal/src/main/kotlin/org/polyfrost/oneconfig/internal/ui/components/dropdown/DropdownMenu.kt
@@ -50,19 +50,12 @@ class DropdownPositionProvider(
             it >= 0 && it + popupContentSize.width <= windowSize.width
         } ?: toLeft
 
-        val toBottom = maxOf(anchorBounds.bottom + contentOffsetY)
-        val toTop = anchorBounds.top - contentOffsetY - popupContentSize.height
-        val toCenter = anchorBounds.top - popupContentSize.height / 2
-        val toDisplayBottom = windowSize.height - popupContentSize.height
-        var y = sequenceOf(toBottom, toTop, toCenter, toDisplayBottom).firstOrNull {
-            it + popupContentSize.height <= windowSize.height
-        } ?: toTop
-
-        val aboveAnchor = anchorBounds.top + contentOffsetY
-        val belowAnchor = windowSize.height - anchorBounds.bottom - contentOffsetY
-
-        if (belowAnchor >= aboveAnchor) {
-            y = anchorBounds.bottom + contentOffsetY
+        val spaceAbove = anchorBounds.top - contentOffsetY
+        val spaceBelow = windowSize.height - anchorBounds.bottom - contentOffsetY
+        var y = if (spaceBelow >= spaceAbove) {
+            anchorBounds.bottom + contentOffsetY
+        } else {
+            anchorBounds.top - contentOffsetY - popupContentSize.height
         }
 
         if (y + popupContentSize.height > windowSize.height) {


### PR DESCRIPTION
## Description

Fixes the dropdown to open on the side of with more available space

Previously it would switch from the top to bottom for no reason when theres more space at the top:

https://github.com/user-attachments/assets/5f324656-3b64-4f1d-8041-645859414bd0

## Checklist

- [x] I made a clear description of what was changed
- [x] I stated why these changes were necessary
- [x] I updated documentation or said what needs to be updated
- [x] I made sure these changes are backwards compatible
- [x] This pull request is for one feature/bug fix
