### PR TITLE
fix(ui): disallow renavigation to current page

### DIFF
--- a/modules/internal/src/main/kotlin/org/polyfrost/oneconfig/internal/ui/shell/Data.kt
+++ b/modules/internal/src/main/kotlin/org/polyfrost/oneconfig/internal/ui/shell/Data.kt
@@ -136,6 +136,7 @@ object LocalNavController {
 
         /** [clearSearch] is off when the navigation only restores a page the user was already on */
         fun navigate(route: Any, clearSearch: Boolean = true) {
+            if (route == currentEntry.route) return
             val host = host() ?: return
             forwardStack.clear()
             backStack.addLast(currentEntry)


### PR DESCRIPTION
## Description
Title

## Related Issue(s)

Fixes this issue in #1019:
Clicking on the same section multiple times should not reopen the same page, especially when it results in a strange ghosting effect. (this also breaks the forwards and backwards arrows)

## Checklist

- [x] I made a clear description of what was changed
- [x] I stated why these changes were necessary
- [x] I updated documentation or said what needs to be updated
- [x] I made sure these changes are backwards compatible
- [x] This pull request is for one feature/bug fix
