### PR TITLE
fix(ui): reopen smoothly during close animation

### DIFF
--- a/minecraft/src/main/kotlin/org/polyfrost/oneconfig/internal/ui/compose/impls/HudEditorUIScreen.kt
+++ b/minecraft/src/main/kotlin/org/polyfrost/oneconfig/internal/ui/compose/impls/HudEditorUIScreen.kt
@@ -45,9 +45,18 @@ class HudEditorUIScreen : ComposeScreen() {
         UiSounds.play(UiSoundEvent.CLOSE)
     }
 
+    private fun cancelClose(): Boolean {
+        if (!closeRequested) return false
+        closeRequested = false
+        requestOpenCallback?.invoke()
+        UiSounds.play(UiSoundEvent.OPEN)
+        return true
+    }
+
     @Volatile private var returningToOneConfig = false
 
     private var requestCloseCallback: (() -> Unit)? = null
+    private var requestOpenCallback: (() -> Unit)? = null
 
     override val scrollSpeed: Float get() = 0.5f
 
@@ -79,12 +88,11 @@ class HudEditorUIScreen : ComposeScreen() {
         }
         val toggleKey = OneConfigConfig.oneConfigKeybind.keyCodes?.firstOrNull()
         if (toggleKey != null && key == toggleKey && !KeybindRecordingBus.isRecording) {
+            if (closeRequested) return cancelClose()
             if (OneConfigConfig.keybindClosesGui) {
-                if (!closeRequested) {
-                    OneConfigConfig.notifyKeybindClosedGui()
-                    beginClose()
-                    requestCloseCallback?.invoke()
-                }
+                OneConfigConfig.notifyKeybindClosedGui()
+                beginClose()
+                requestCloseCallback?.invoke()
             } else {
                 returningToOneConfig = true
                 Platform.screen().display(OneConfigUIScreen())
@@ -131,8 +139,10 @@ class HudEditorUIScreen : ComposeScreen() {
         LaunchedEffect(Unit) { visible = true }
 
         val requestClose: () -> Unit = { visible = false }
+        val requestOpen: () -> Unit = { visible = true }
         SideEffect {
             requestCloseCallback = requestClose
+            requestOpenCallback = requestOpen
         }
 
         val exitMs = guiCloseAnimationMillis().toInt()

--- a/minecraft/src/main/kotlin/org/polyfrost/oneconfig/internal/ui/compose/impls/OneConfigUIScreen.kt
+++ b/minecraft/src/main/kotlin/org/polyfrost/oneconfig/internal/ui/compose/impls/OneConfigUIScreen.kt
@@ -94,8 +94,22 @@ class OneConfigUIScreen @JvmOverloads constructor(
         closeRequested = true
         closeRequestedAt = System.currentTimeMillis()
         closeAnimationMs = guiCloseAnimationMillis()
-        markClosed()
         UiSounds.play(UiSoundEvent.CLOSE)
+    }
+
+    private fun cancelClose(): Boolean {
+        if (!closeRequested) return false
+
+        // Resume the opening blur animation from current blur intensity
+        val now = System.currentTimeMillis()
+        val blurProgress = if (closeAnimationMs <= 0L) 0f
+            else 1f - easeOutExpo((now - closeRequestedAt).toFloat() / closeAnimationMs)
+        openedAt = now - (blurProgress.coerceIn(0f, 1f) * OPEN_ANIMATION_MS).toLong()
+
+        closeRequested = false
+        requestOpenCallback?.invoke()
+        UiSounds.play(UiSoundEvent.OPEN)
+        return true
     }
 
     /** The page this screen is showing which survives the scene being disposed and rebuilt */
@@ -225,12 +239,11 @@ class OneConfigUIScreen @JvmOverloads constructor(
         }
         val toggleKey = OneConfigConfig.oneConfigKeybind.keyCodes?.firstOrNull()
         if (toggleKey != null && key == toggleKey && !KeybindRecordingBus.isRecording) {
+            if (closeRequested) return cancelClose()
             if (OneConfigConfig.keybindClosesGui) {
-                if (!closeRequested) {
-                    OneConfigConfig.notifyKeybindClosedGui()
-                    beginClose()
-                    requestCloseCallback?.invoke()
-                }
+                OneConfigConfig.notifyKeybindClosedGui()
+                beginClose()
+                requestCloseCallback?.invoke()
             } else {
                 HudManager.openEditor()
             }
@@ -264,6 +277,7 @@ class OneConfigUIScreen @JvmOverloads constructor(
         // and that would queue a fullscreen blur which smears over the popup so bail unless we are current
         if (Platform.screen().current<Any?>() !== this) return
         if (closeRequested && System.currentTimeMillis() - closeRequestedAt >= closeAnimationMs) {
+            markClosed()
             //? if < 1.21.8
             //renderBackground(ctx, mouseX, mouseY, tickDelta)
             Platform.screen().close()
@@ -321,6 +335,7 @@ class OneConfigUIScreen @JvmOverloads constructor(
 
     /** Holds a reference to the close-animation trigger from Compose */
     private var requestCloseCallback: (() -> Unit)? = null
+    private var requestOpenCallback: (() -> Unit)? = null
 
     @Composable
     override fun compose() {
@@ -336,6 +351,9 @@ class OneConfigUIScreen @JvmOverloads constructor(
             onCloseRequest = { beginClose() },
             onCloseReady = { closeRequest ->
                 requestCloseCallback = closeRequest
+            },
+            onOpenReady = { openRequest ->
+                requestOpenCallback = openRequest
             },
         ) { }
     }

--- a/modules/internal/src/main/kotlin/org/polyfrost/oneconfig/internal/ui/OneConfigInterface.kt
+++ b/modules/internal/src/main/kotlin/org/polyfrost/oneconfig/internal/ui/OneConfigInterface.kt
@@ -75,6 +75,7 @@ fun OneConfigInterface(
     restoring: Boolean = false,
     onCloseRequest: () -> Unit = {},
     onCloseReady: ((requestClose: () -> Unit) -> Unit)? = null,
+    onOpenReady: ((requestOpen: () -> Unit) -> Unit)? = null,
     shellBackdrop: DrawScope.(Offset) -> Unit = {}
 ) {
     ThemeRegistry.init()
@@ -139,9 +140,11 @@ fun OneConfigInterface(
     }
 
     val requestClose: () -> Unit = { visible = false }
+    val requestOpen: () -> Unit = { visible = true }
 
     SideEffect {
         onCloseReady?.invoke(requestClose)
+        onOpenReady?.invoke(requestOpen)
     }
 
     CompositionLocalProvider(LocalCloseRequest provides requestClose) {


### PR DESCRIPTION
## Description
- Makes reopening oneconfig while it is closing reverse UI and blur animations smoothly

Before (trying to reopen during closing animation switched between UI screens instead of reopening):

https://github.com/user-attachments/assets/c536c891-6432-4276-89c4-10d09b06ccbb

After:

https://github.com/user-attachments/assets/60653e4d-77b7-4f80-a2ab-ec5ac97ac1f0



## Related Issue(s)
Fixes this issue in #1019:
> the HUD editor screen opening behavior is weird. After closing the OneConfig or HUD editor screen and pressing RSHIFT again to reopen it while it is closing leads to it alternating between opening the HUD editor and the OneConfig screen.

## Checklist

- [x] I made a clear description of what was changed
- [x] I stated why these changes were necessary
- [x] I updated documentation or said what needs to be updated
- [x] I made sure these changes are backwards compatible
- [x] This pull request is for one feature/bug fix
