### PR TITLE
fix(keybinds): minor fixes

### DIFF
--- a/minecraft/src/main/java/org/polyfrost/oneconfig/api/ui/v1/keybind/internal/MinecraftKeybindBridgeImpl.java
+++ b/minecraft/src/main/java/org/polyfrost/oneconfig/api/ui/v1/keybind/internal/MinecraftKeybindBridgeImpl.java
@@ -372,6 +372,8 @@ public final class MinecraftKeybindBridgeImpl implements MinecraftKeybindBridge 
     }
 
     private static InputConstants.Key keyFor(OneConfigKeybind bind) {
+        if (!bind.isBound()) return InputConstants.UNKNOWN;
+
         return bind.isMousePrimary()
             ? MinecraftKeybindCodec.mouse(bind.getBoundCode())
             : MinecraftKeybindCodec.keysym(bind.getBoundCode());

--- a/minecraft/src/main/java/org/polyfrost/oneconfig/internal/mixin/keybind/Mixin_OneConfigKeybindRebind.java
+++ b/minecraft/src/main/java/org/polyfrost/oneconfig/internal/mixin/keybind/Mixin_OneConfigKeybindRebind.java
@@ -139,6 +139,8 @@ public class Mixin_OneConfigKeybindRebind implements OneConfigKeybindRecorder {
 
     @Override
     public void oneconfig$recordKey(int keyCode) {
+        //? if >= 26.3
+        if (keyCode <= 0) return;
         if (!oneconfig$begin()) return;
         oneconfig$keys.add(keyCode);
         oneconfig$preview();


### PR DESCRIPTION
## Description
- Convert unbound keybinds to `InputConstants.UNKNOWN` to avoid invalid -1 SDL scancode
- Ignore unknown SDL scancodes (<= 0) during keybind recording
