### PR TITLE
Complete Performance Overhaul

### DIFF
--- a/minecraft/src/main/java/org/polyfrost/oneconfig/internal/OneConfig.java
+++ b/minecraft/src/main/java/org/polyfrost/oneconfig/internal/OneConfig.java
@@ -227,7 +227,7 @@ public class OneConfig
                 HudEditorToggleEvent.class, e -> {
                     if (e.open) {
                         if (!(Platform.screen().current() instanceof HudEditorUIScreen)) {
-                            Platform.screen().display(new HudEditorUIScreen());
+                            Platform.screen().display(HudEditorUIScreen.open());
                         }
                     } else {
                         if (Platform.screen().current() instanceof HudEditorUIScreen) {

--- a/minecraft/src/main/java/org/polyfrost/oneconfig/internal/mixin/events/Mixin_ReceivePacketEvent.java
+++ b/minecraft/src/main/java/org/polyfrost/oneconfig/internal/mixin/events/Mixin_ReceivePacketEvent.java
@@ -15,7 +15,6 @@ public class Mixin_ReceivePacketEvent {
 
     @Inject(method = "channelRead0(Lio/netty/channel/ChannelHandlerContext;Lnet/minecraft/network/protocol/Packet;)V", at = @At("HEAD"), cancellable = true)
     private void packetReceiveCallback(ChannelHandlerContext ctx, Packet<?> packet, CallbackInfo ci) {
-        // every inbound packet reaches this, hundreds a second on a busy server
         if (!EventManager.INSTANCE.hasListeners(PacketEvent.Receive.class)) return;
         PacketEvent.Receive event = new PacketEvent.Receive(packet);
         EventManager.INSTANCE.post(event);

--- a/minecraft/src/main/java/org/polyfrost/oneconfig/internal/mixin/events/Mixin_ReceivePacketEvent.java
+++ b/minecraft/src/main/java/org/polyfrost/oneconfig/internal/mixin/events/Mixin_ReceivePacketEvent.java
@@ -15,6 +15,8 @@ public class Mixin_ReceivePacketEvent {
 
     @Inject(method = "channelRead0(Lio/netty/channel/ChannelHandlerContext;Lnet/minecraft/network/protocol/Packet;)V", at = @At("HEAD"), cancellable = true)
     private void packetReceiveCallback(ChannelHandlerContext ctx, Packet<?> packet, CallbackInfo ci) {
+        // every inbound packet reaches this, hundreds a second on a busy server
+        if (!EventManager.INSTANCE.hasListeners(PacketEvent.Receive.class)) return;
         PacketEvent.Receive event = new PacketEvent.Receive(packet);
         EventManager.INSTANCE.post(event);
         if (event.cancelled) {

--- a/minecraft/src/main/java/org/polyfrost/oneconfig/internal/mixin/events/Mixin_RenderLivingEntityEvent.java
+++ b/minecraft/src/main/java/org/polyfrost/oneconfig/internal/mixin/events/Mixin_RenderLivingEntityEvent.java
@@ -42,7 +42,6 @@ public class Mixin_RenderLivingEntityEvent {
     *///?} else {
     /*private void onPreEntityRenderCallback(LivingEntity entity, float entityYaw, float partialTicks, PoseStack matrixStack, MultiBufferSource buffer, int packedLight, CallbackInfo ci) {
     *///?}
-        // runs for every living entity on every frame, so build nothing when nothing is listening
         if (!EventManager.INSTANCE.hasListeners(RenderLivingEvent.Pre.class)) return;
 
         //? >= 1.21.2 {

--- a/minecraft/src/main/java/org/polyfrost/oneconfig/internal/mixin/events/Mixin_RenderLivingEntityEvent.java
+++ b/minecraft/src/main/java/org/polyfrost/oneconfig/internal/mixin/events/Mixin_RenderLivingEntityEvent.java
@@ -42,6 +42,8 @@ public class Mixin_RenderLivingEntityEvent {
     *///?} else {
     /*private void onPreEntityRenderCallback(LivingEntity entity, float entityYaw, float partialTicks, PoseStack matrixStack, MultiBufferSource buffer, int packedLight, CallbackInfo ci) {
     *///?}
+        // runs for every living entity on every frame, so build nothing when nothing is listening
+        if (!EventManager.INSTANCE.hasListeners(RenderLivingEvent.Pre.class)) return;
 
         //? >= 1.21.2 {
         double x = entity.x;
@@ -77,6 +79,7 @@ public class Mixin_RenderLivingEntityEvent {
     *///?} else {
     /*private void onPostEntityRenderCallback(LivingEntity entity, float entityYaw, float partialTicks, PoseStack matrixStack, MultiBufferSource buffer, int packedLight, CallbackInfo ci) {
     *///?}
+        if (!EventManager.INSTANCE.hasListeners(RenderLivingEvent.Post.class)) return;
         //? >= 1.21.2 {
         double x = entity.x;
         double y = entity.y;

--- a/minecraft/src/main/kotlin/org/polyfrost/oneconfig/internal/compat/ModMenuEntrypoint.kt
+++ b/minecraft/src/main/kotlin/org/polyfrost/oneconfig/internal/compat/ModMenuEntrypoint.kt
@@ -13,7 +13,7 @@ internal object ModMenuEntrypoint : ModMenuApi {
     override fun getModConfigScreenFactory(): ConfigScreenFactory<*> {
         if (CompatLoader.hasMod(ROOT_MOD_ID)) return ConfigScreenFactory<Screen> { null }
         return try {
-            ConfigScreenFactory { OneConfigUIScreen() }
+            ConfigScreenFactory { OneConfigUIScreen.open() }
         } catch (e: LinkageError) {
             reportUnlinkable(e)
             ConfigScreenFactory<Screen> { null }
@@ -25,7 +25,7 @@ internal object ModMenuEntrypoint : ModMenuApi {
             val factories = ConfigManager.active().trees()
                 .filter { it.id != null }
                 .associateTo(mutableMapOf()) { it.id to ConfigScreenFactory { _ -> OneConfigUIScreen(initialTree = it) } }
-            factories.putIfAbsent(ROOT_MOD_ID, ConfigScreenFactory { _ -> OneConfigUIScreen() })
+            factories.putIfAbsent(ROOT_MOD_ID, ConfigScreenFactory { _ -> OneConfigUIScreen.open() })
             factories
         } catch (e: LinkageError) {
             reportUnlinkable(e)

--- a/minecraft/src/main/kotlin/org/polyfrost/oneconfig/internal/ui/compose/ComposePreloader.kt
+++ b/minecraft/src/main/kotlin/org/polyfrost/oneconfig/internal/ui/compose/ComposePreloader.kt
@@ -190,6 +190,9 @@ object ComposePreloader {
         // through, so keep watching until a pass has run against a world
         if (warmed?.inWorld != true && passes < MAX_PASSES && System.nanoTime() < deadline) {
             SkiaCtx.queueWarmup(::warmUp)
+        } else {
+            OneConfigUIScreen.endPrewarmShared()
+            HudEditorUIScreen.endPrewarmShared()
         }
     }
 

--- a/minecraft/src/main/kotlin/org/polyfrost/oneconfig/internal/ui/compose/ComposePreloader.kt
+++ b/minecraft/src/main/kotlin/org/polyfrost/oneconfig/internal/ui/compose/ComposePreloader.kt
@@ -31,12 +31,6 @@ object ComposePreloader {
         SkiaCtx.queueWarmup(::warmUp)
     }
 
-    /**
-     * loads the classes behind every settings control, off the render thread
-     *
-     * a class is only loaded when something first reaches it, which happens inside a composition on
-     * the frame that shows it, and on a large pack that costs 40 to 50 ms each. linking is enough.
-     */
     private fun warmClasses() {
         val loader = ComposePreloader::class.java.classLoader ?: return
         Multithreading.submit {
@@ -48,7 +42,6 @@ object ComposePreloader {
         }
     }
 
-    /** every class under these is a first touch waiting to land on the frame that shows it */
     private val WARM_PACKAGES = listOf(
         "org/polyfrost/oneconfig/internal/ui/api/",
         "org/polyfrost/oneconfig/internal/ui/components/",
@@ -59,7 +52,6 @@ object ComposePreloader {
         "org/polyfrost/oneconfig/internal/ui/themes/",
     )
 
-    /** read off our own jars, so renaming or adding a screen never leaves this list behind */
     private fun ourUiClasses(): List<String> = FabricLoader.getInstance().allMods
         .filter { it.metadata.id.startsWith("org_polyfrost_oneconfig") }
         .flatMap { it.rootPaths }
@@ -74,7 +66,6 @@ object ComposePreloader {
             }.getOrDefault(emptyList())
         }
 
-    // named by the stall watch, so these are listed rather than derived
     private val LAZY_LIBRARY_CLASSES = listOf(
         "androidx.compose.ui.graphics.SkiaBackedPath_skikoKt",
         "androidx.compose.foundation.lazy.LazyListItemProviderKt",
@@ -116,38 +107,19 @@ object ComposePreloader {
         "androidx.compose.foundation.text.TextFieldKeyInput",
     )
 
-    /**
-     * What the UI composes against
-     *
-     * Joining a world is the last of these to settle, and it is also the point after which every
-     * frame belongs to someone, so a pass that runs in one ends the watch.
-     */
     private data class Inputs(val width: Int, val height: Int, val configs: Int, val inWorld: Boolean)
 
-    /** The inputs of the last pass that succeeded, or null while none has */
     private var warmed: Inputs? = null
     private var passes = 0
 
-    /** A pass is spread over frames, so its cost and length are accumulated rather than timed once */
     private var passNanos = 0L
     private var passFrames = 0
 
-    // the total says what the warm-up cost, only the worst frame says whether it was felt: the same
-    // pass has come in at 3.7 s and at 15 s, and those are the same number spread very differently
     private var worstFrameNanos = 0L
     private var deadline = 0L
 
-    /**
-     * Composes the shared screen offscreen until it is composing the real thing
-     *
-     * The first frame that can warm up is not the frame worth warming: the window is still 854x480
-     * and most mods have not registered, so one pass builds the wrong size against a fraction of the
-     * data. So it watches instead, and a pass that finds nothing changed costs three reads.
-     */
     private fun warmUp() {
         if (waitDeadline == 0L) waitDeadline = System.nanoTime() + WAIT_NANOS
-        // the first pass is one heavy frame, so it waits for the loading screen, where a hitch is
-        // hidden and the window and the mod list are already what a real open will see
         if (!readyToWarm()) {
             if (System.nanoTime() < waitDeadline) SkiaCtx.queueWarmup(::warmUp)
             return
@@ -161,8 +133,6 @@ object ComposePreloader {
         )
 
         if (inputs != warmed) {
-            // the config screen warms a few frames per call, so a pass spans several real frames:
-            // count it, and report its cost, only once it has actually finished
             val startNanos = System.nanoTime()
             val done = OneConfigUIScreen.prewarmShared()
             val frameNanos = System.nanoTime() - startNanos
@@ -171,7 +141,6 @@ object ComposePreloader {
             if (frameNanos > worstFrameNanos) worstFrameNanos = frameNanos
             if (done) {
                 passes++
-                // the editor is warmed after, so a failure there cannot cost the config screen its own
                 HudEditorUIScreen.prewarmShared()
                 warmed = inputs
                 LOG.info(
@@ -186,8 +155,6 @@ object ComposePreloader {
             }
         }
 
-        // mods register their configs across the loading screen and the window is resized part way
-        // through, so keep watching until a pass has run against a world
         if (warmed?.inWorld != true && passes < MAX_PASSES && System.nanoTime() < deadline) {
             SkiaCtx.queueWarmup(::warmUp)
         } else {
@@ -196,26 +163,17 @@ object ComposePreloader {
         }
     }
 
-    /**
-     * Whether a heavy frame would go unnoticed
-     *
-     * Singleplayer stops on [LevelLoadingScreen], a server on [ConnectScreen] first, and a world
-     * already loaded is where the warm-up used to run anyway
-     */
     private fun readyToWarm(): Boolean {
         if (Minecraft.getInstance().level != null) return true
         val screen = Platform.screen().current<Any?>()
         return screen is LevelLoadingScreen || screen is ConnectScreen || screen is ProgressScreen
     }
 
-    /** How long to wait for a world before giving up, after which the first open builds the UI */
     private const val WAIT_NANOS = 600_000_000_000L
 
     private var waitDeadline = 0L
 
-    /** Enough passes to follow the window, the mod list and the world, few enough to stay bounded */
     private const val MAX_PASSES = 8
 
-    /** Long enough to reach a world on a slow load, short enough not to watch a menu forever */
     private const val WATCH_NANOS = 300_000_000_000L
 }

--- a/minecraft/src/main/kotlin/org/polyfrost/oneconfig/internal/ui/compose/ComposePreloader.kt
+++ b/minecraft/src/main/kotlin/org/polyfrost/oneconfig/internal/ui/compose/ComposePreloader.kt
@@ -1,26 +1,19 @@
 package org.polyfrost.oneconfig.internal.ui.compose
 
-import androidx.compose.ui.InternalComposeUiApi
-import androidx.compose.ui.geometry.Offset
-import androidx.compose.ui.graphics.asComposeCanvas
-import androidx.compose.ui.input.pointer.PointerEventType
-import androidx.compose.ui.platform.FrameRecomposer
-import androidx.compose.ui.scene.CanvasLayersComposeScene
-import androidx.compose.ui.scene.ComposeScene
-import androidx.compose.ui.scene.SingleComposeSceneRenderingScope
-import androidx.compose.ui.unit.Density
-import androidx.compose.ui.unit.IntSize
-import org.jetbrains.skia.ImageInfo
-import org.jetbrains.skia.Surface
+import net.fabricmc.loader.api.FabricLoader
+import net.minecraft.client.Minecraft
 import org.polyfrost.oneconfig.api.notifications.v1.NotificationsManager
 import org.polyfrost.oneconfig.api.platform.v1.Platform
-import org.polyfrost.oneconfig.internal.ui.OneConfigInterface
+import org.polyfrost.oneconfig.internal.ui.api.ConfigRegistry
+import org.polyfrost.oneconfig.internal.ui.compose.impls.HudEditorUIScreen
+import org.polyfrost.oneconfig.internal.ui.compose.impls.OneConfigUIScreen
+import org.polyfrost.oneconfig.utils.v1.Multithreading
 import org.slf4j.LoggerFactory
+import java.nio.file.Files
 
 /**
- * Warms up the Compose UI by rendering [OneConfigInterface] so the first screen open doesn't stutter
+ * Builds the OneConfig UI while nobody is waiting for a frame, so that opening it costs nothing
  */
-@OptIn(InternalComposeUiApi::class)
 object ComposePreloader {
     private val LOG = LoggerFactory.getLogger(ComposePreloader::class.java)
 
@@ -31,54 +24,168 @@ object ComposePreloader {
         if (gpuWarmed) return
         gpuWarmed = true
         NotificationsManager.ensureInitialized()
-        SkiaCtx.queueWarmup {
+        warmClasses()
+        SkiaCtx.queueWarmup(::warmUp)
+    }
+
+    /**
+     * loads the classes behind every settings control, off the render thread
+     *
+     * a class is only loaded when something first reaches it, which happens inside a composition on
+     * the frame that shows it, and on a large pack that costs 40 to 50 ms each. linking is enough.
+     */
+    private fun warmClasses() {
+        val loader = ComposePreloader::class.java.classLoader ?: return
+        Multithreading.submit {
             val startNanos = System.nanoTime()
-            val w = Platform.screen().windowWidth().takeIf { it > 0 } ?: 1280
-            val h = Platform.screen().windowHeight().takeIf { it > 0 } ?: 720
-            var recomposer: FrameRecomposer? = null
-            var scene: ComposeScene? = null
-            var surface: Surface? = null
-            try {
-                val renderScope = SingleComposeSceneRenderingScope {}
-                val liveRecomposer = FrameRecomposer(RenderThreadDispatcher).also { recomposer = it }
-                val liveScene = CanvasLayersComposeScene(
-                    frameRecomposer = liveRecomposer,
-                    platformContext = ComposeSceneContextImpl.platformContext,
-                ).also { scene = it }
-                val liveSurface = Surface.makeRenderTarget(
-                    SkiaCtx.directContext,
-                    false,
-                    ImageInfo.makeN32Premul(w, h),
-                ).also { surface = it }
-                liveScene.setContent {
-                    OneConfigInterface(
-                        windowWidth = w.toFloat(),
-                        windowHeight = h.toFloat(),
-                    )
-                }
-                liveScene.size = IntSize(w, h)
-                liveScene.density = Density(1f)
-                liveScene.sendPointerEvent(PointerEventType.Move, position = Offset(50f, 50f))
-                with(renderScope) {
-                    liveScene.render(liveRecomposer, liveSurface.canvas.asComposeCanvas(), System.nanoTime())
-                }
-                liveSurface.flushAndSubmit()
-                LOG.info("Compose GPU warm-up finished in {} ms", (System.nanoTime() - startNanos) / 1_000_000)
-            } catch (e: Throwable) {
-                LOG.warn("Compose GPU warm-up failed", e)
-            } finally {
-                closeQuietly(scene)
-                closeQuietly(recomposer)
-                closeQuietly(surface)
-            }
+            val names = ourUiClasses() + LAZY_LIBRARY_CLASSES
+            val warmed = names.count { runCatching { Class.forName(it, false, loader) }.isSuccess }
+            LOG.info("Warmed {} of {} UI classes in {} ms", warmed, names.size,
+                (System.nanoTime() - startNanos) / 1_000_000)
         }
     }
 
-    private fun closeQuietly(closeable: AutoCloseable?) {
-        try {
-            closeable?.close()
-        } catch (t: Throwable) {
-            LOG.debug("Ignoring failure while closing a Compose warm-up resource", t)
+    /** every class under these is a first touch waiting to land on the frame that shows it */
+    private val WARM_PACKAGES = listOf(
+        "org/polyfrost/oneconfig/internal/ui/api/",
+        "org/polyfrost/oneconfig/internal/ui/components/",
+        "org/polyfrost/oneconfig/internal/ui/hud/",
+        "org/polyfrost/oneconfig/internal/ui/keybind/",
+        "org/polyfrost/oneconfig/internal/ui/screens/",
+        "org/polyfrost/oneconfig/internal/ui/search/",
+        "org/polyfrost/oneconfig/internal/ui/themes/",
+    )
+
+    /** read off our own jars, so renaming or adding a screen never leaves this list behind */
+    private fun ourUiClasses(): List<String> = FabricLoader.getInstance().allMods
+        .filter { it.metadata.id.startsWith("org_polyfrost_oneconfig") }
+        .flatMap { it.rootPaths }
+        .flatMap { root ->
+            runCatching {
+                Files.walk(root).use { paths ->
+                    paths.map { path -> root.relativize(path).joinToString("/") }
+                        .filter { name -> name.endsWith(".class") && WARM_PACKAGES.any(name::startsWith) }
+                        .map { name -> name.removeSuffix(".class").replace('/', '.') }
+                        .toList()
+                }
+            }.getOrDefault(emptyList())
+        }
+
+    // named by the stall watch, so these are listed rather than derived
+    private val LAZY_LIBRARY_CLASSES = listOf(
+        "androidx.compose.ui.graphics.SkiaBackedPath_skikoKt",
+        "androidx.compose.foundation.lazy.LazyListItemProviderKt",
+        "androidx.compose.ui.text.SkiaParagraph",
+        "androidx.compose.ui.text.platform.DesktopFont_desktopKt",
+        "androidx.compose.ui.text.platform.FontCache",
+        "androidx.compose.foundation.lazy.LazyListKt",
+        "androidx.compose.foundation.lazy.LazyListMeasureKt",
+        "androidx.compose.foundation.lazy.LazyListState",
+        "androidx.compose.foundation.lazy.LazyListMeasuredItem",
+        "androidx.compose.foundation.lazy.LazyListMeasuredItemProvider",
+        "androidx.compose.foundation.lazy.LazyListMeasureResult",
+        "androidx.compose.foundation.lazy.LazyListIntervalContent",
+        "androidx.compose.foundation.lazy.LazyListItemProviderImpl",
+        "androidx.compose.foundation.lazy.LazyDslKt",
+        "androidx.compose.foundation.lazy.layout.LazyLayoutMeasureScopeImpl",
+        "androidx.compose.foundation.lazy.layout.LazyLayoutItemContentFactory",
+        "androidx.compose.foundation.lazy.layout.LazySaveableStateHolder",
+        "androidx.compose.foundation.lazy.layout.LazyLayoutPinnableItemKt",
+        "kotlinx.coroutines.flow.internal.ChannelFlowTransformLatest",
+        "kotlinx.coroutines.flow.internal.ChannelFlowOperator",
+        "kotlinx.coroutines.flow.internal.ChannelFlow",
+        "kotlinx.coroutines.flow.internal.MergeKt",
+        "org.commonmark.parser.Parser",
+        "org.commonmark.internal.DocumentParser",
+        "org.commonmark.internal.ParagraphParser",
+        "org.commonmark.internal.LinkReferenceDefinitionParser",
+        "androidx.compose.ui.text.TextMeasurer",
+        "androidx.compose.ui.text.TextLayoutCache",
+        "androidx.compose.ui.text.SpanStyle",
+        "androidx.compose.ui.text.TextStyle",
+        "androidx.compose.ui.text.ParagraphStyle",
+        "androidx.compose.ui.text.ParagraphKt",
+        "androidx.compose.ui.text.platform.ParagraphBuilder",
+        "androidx.compose.foundation.text.TextFieldDelegateKt",
+        "androidx.compose.foundation.text.TextFieldSize",
+        "androidx.compose.foundation.text.TextFieldScrollKt",
+        "androidx.compose.foundation.text.KeyMapping_skikoKt",
+        "androidx.compose.foundation.text.TextFieldKeyInput",
+    )
+
+    /**
+     * What the UI composes against
+     *
+     * Joining a world is the last of these to settle, and it is also the point after which every
+     * frame belongs to someone, so a pass that runs in one ends the watch.
+     */
+    private data class Inputs(val width: Int, val height: Int, val configs: Int, val inWorld: Boolean)
+
+    /** The inputs of the last pass that succeeded, or null while none has */
+    private var warmed: Inputs? = null
+    private var passes = 0
+
+    /** A pass is spread over frames, so its cost and length are accumulated rather than timed once */
+    private var passNanos = 0L
+    private var passFrames = 0
+
+    // the total says what the warm-up cost, only the worst frame says whether it was felt: the same
+    // pass has come in at 3.7 s and at 15 s, and those are the same number spread very differently
+    private var worstFrameNanos = 0L
+    private var deadline = 0L
+
+    /**
+     * Composes the shared screen offscreen until it is composing the real thing
+     *
+     * The first frame that can warm up is not the frame worth warming: the window is still 854x480
+     * and most mods have not registered, so one pass builds the wrong size against a fraction of the
+     * data. So it watches instead, and a pass that finds nothing changed costs three reads.
+     */
+    private fun warmUp() {
+        if (deadline == 0L) deadline = System.nanoTime() + WATCH_NANOS
+        val inputs = Inputs(
+            width = Platform.screen().windowWidth(),
+            height = Platform.screen().windowHeight(),
+            configs = ConfigRegistry.configs.size,
+            inWorld = Minecraft.getInstance().level != null,
+        )
+
+        if (inputs != warmed) {
+            // the config screen warms a few frames per call, so a pass spans several real frames:
+            // count it, and report its cost, only once it has actually finished
+            val startNanos = System.nanoTime()
+            val done = OneConfigUIScreen.prewarmShared()
+            val frameNanos = System.nanoTime() - startNanos
+            passNanos += frameNanos
+            passFrames++
+            if (frameNanos > worstFrameNanos) worstFrameNanos = frameNanos
+            if (done) {
+                passes++
+                // the editor is warmed after, so a failure there cannot cost the config screen its own
+                HudEditorUIScreen.prewarmShared()
+                warmed = inputs
+                LOG.info(
+                    "OneConfig UI warm-up pass {} in {} ms over {} frame(s), worst {} ms ({} configs, {}x{}, {})",
+                    passes, passNanos / 1_000_000, passFrames, worstFrameNanos / 1_000_000,
+                    inputs.configs, inputs.width, inputs.height,
+                    if (inputs.inWorld) "in world" else "no world",
+                )
+                passNanos = 0L
+                passFrames = 0
+                worstFrameNanos = 0L
+            }
+        }
+
+        // mods register their configs across the loading screen and the window is resized part way
+        // through, so keep watching until a pass has run against a world
+        if (warmed?.inWorld != true && passes < MAX_PASSES && System.nanoTime() < deadline) {
+            SkiaCtx.queueWarmup(::warmUp)
         }
     }
+
+    /** Enough passes to follow the window, the mod list and the world, few enough to stay bounded */
+    private const val MAX_PASSES = 8
+
+    /** Long enough to reach a world on a slow load, short enough not to watch a menu forever */
+    private const val WATCH_NANOS = 300_000_000_000L
 }

--- a/minecraft/src/main/kotlin/org/polyfrost/oneconfig/internal/ui/compose/ComposePreloader.kt
+++ b/minecraft/src/main/kotlin/org/polyfrost/oneconfig/internal/ui/compose/ComposePreloader.kt
@@ -2,6 +2,9 @@ package org.polyfrost.oneconfig.internal.ui.compose
 
 import net.fabricmc.loader.api.FabricLoader
 import net.minecraft.client.Minecraft
+import net.minecraft.client.gui.screens.ConnectScreen
+import net.minecraft.client.gui.screens.LevelLoadingScreen
+import net.minecraft.client.gui.screens.ProgressScreen
 import org.polyfrost.oneconfig.api.notifications.v1.NotificationsManager
 import org.polyfrost.oneconfig.api.platform.v1.Platform
 import org.polyfrost.oneconfig.internal.ui.api.ConfigRegistry
@@ -142,6 +145,13 @@ object ComposePreloader {
      * data. So it watches instead, and a pass that finds nothing changed costs three reads.
      */
     private fun warmUp() {
+        if (waitDeadline == 0L) waitDeadline = System.nanoTime() + WAIT_NANOS
+        // the first pass is one heavy frame, so it waits for the loading screen, where a hitch is
+        // hidden and the window and the mod list are already what a real open will see
+        if (!readyToWarm()) {
+            if (System.nanoTime() < waitDeadline) SkiaCtx.queueWarmup(::warmUp)
+            return
+        }
         if (deadline == 0L) deadline = System.nanoTime() + WATCH_NANOS
         val inputs = Inputs(
             width = Platform.screen().windowWidth(),
@@ -182,6 +192,23 @@ object ComposePreloader {
             SkiaCtx.queueWarmup(::warmUp)
         }
     }
+
+    /**
+     * Whether a heavy frame would go unnoticed
+     *
+     * Singleplayer stops on [LevelLoadingScreen], a server on [ConnectScreen] first, and a world
+     * already loaded is where the warm-up used to run anyway
+     */
+    private fun readyToWarm(): Boolean {
+        if (Minecraft.getInstance().level != null) return true
+        val screen = Platform.screen().current<Any?>()
+        return screen is LevelLoadingScreen || screen is ConnectScreen || screen is ProgressScreen
+    }
+
+    /** How long to wait for a world before giving up, after which the first open builds the UI */
+    private const val WAIT_NANOS = 600_000_000_000L
+
+    private var waitDeadline = 0L
 
     /** Enough passes to follow the window, the mod list and the world, few enough to stay bounded */
     private const val MAX_PASSES = 8

--- a/minecraft/src/main/kotlin/org/polyfrost/oneconfig/internal/ui/compose/ComposeScreen.kt
+++ b/minecraft/src/main/kotlin/org/polyfrost/oneconfig/internal/ui/compose/ComposeScreen.kt
@@ -325,6 +325,7 @@ abstract class ComposeScreen(
     }
 
     override fun init() {
+        endPrewarm()
         val hadScene = sceneOrNull != null
         val scene = ensureScene()
         if (scene == null) {
@@ -383,6 +384,11 @@ abstract class ComposeScreen(
         prewarmSurfaceOrNull = null
         prewarmSurfaceW = 0
         prewarmSurfaceH = 0
+    }
+
+    fun endPrewarm() {
+        prewarmCursor = 0
+        releasePrewarmSurface()
     }
 
     /**

--- a/minecraft/src/main/kotlin/org/polyfrost/oneconfig/internal/ui/compose/ComposeScreen.kt
+++ b/minecraft/src/main/kotlin/org/polyfrost/oneconfig/internal/ui/compose/ComposeScreen.kt
@@ -241,12 +241,6 @@ abstract class ComposeScreen(
         return scene
     }
 
-    /**
-     * How far this scene's clock has been pushed ahead of the wall clock
-     *
-     * A warm-up runs animations forward in big steps, and holding that as an offset is what stops
-     * the next real frame handing back a smaller number and walking every Transition backwards.
-     */
     private var clockSkewNanos = 0L
 
     private fun frameNanos(): Long = System.nanoTime() + clockSkewNanos
@@ -254,7 +248,6 @@ abstract class ComposeScreen(
     @Volatile
     private var sceneDirty = true
 
-    /** Set by [init]; the frame it guards re-arms the compose pipeline that closing cleared */
     private var awaitingFirstFrame = false
 
     private var lastPointer: Offset? = null
@@ -332,8 +325,6 @@ abstract class ComposeScreen(
             reportUnavailableAndClose()
             return
         }
-        // a reused scene still holds its composition and its last frame, so the cached blit below
-        // can serve the open. anything that really differs invalidates and sets this again
         if (!hadScene) sceneDirty = true
         awaitingFirstFrame = true
         lastPointer = null
@@ -351,15 +342,12 @@ abstract class ComposeScreen(
         }
     }
 
-    // how far the last call got. reset on completion, so a warm-up running again against a changed
-    // window or mod list starts over rather than reporting itself already done
     private var prewarmCursor = 0
 
     private var prewarmSurfaceOrNull: Surface? = null
     private var prewarmSurfaceW = 0
     private var prewarmSurfaceH = 0
 
-    /** one surface for the whole pass: it is viewport sized and was being rebuilt on every frame */
     private fun prewarmSurface(): Surface? {
         prewarmSurfaceOrNull?.let { if (prewarmSurfaceW == lastSceneW && prewarmSurfaceH == lastSceneH) return it }
         releasePrewarmSurface()
@@ -391,12 +379,6 @@ abstract class ComposeScreen(
         releasePrewarmSurface()
     }
 
-    /**
-     * builds the scene and renders it offscreen before anything asks to see it
-     *
-     * [step] runs before each frame so the caller can drive state across them, and frame times are
-     * advanced by hand so an animation finishes in one frame. false means nothing was kept.
-     */
     protected fun prewarm(frames: Int, budget: Int = frames, step: (Int) -> Unit): Boolean {
         val name = this::class.java.simpleName
         if (ensureScene() == null) {
@@ -415,8 +397,6 @@ abstract class ComposeScreen(
             closeSceneQuietly()
             return false
         }
-        // setContent builds the whole composition, and rendering it on the same frame made one
-        // 2430 ms frame on the title screen. it gets a frame to itself
         if (!hadContent) return false
         val surface = prewarmSurface() ?: run {
             closeSceneQuietly()
@@ -424,8 +404,6 @@ abstract class ComposeScreen(
         }
         try {
             val canvas = surface.canvas.asComposeCanvas()
-            // only as many as the caller allowed: running all of them in one go put the whole
-            // warm-up on a single frame, which was measured at 1332 ms as the world appeared
             val until = minOf(frames, prewarmCursor + budget.coerceAtLeast(1))
             val recomposer = recomposerOrNull
             val scope = renderScopeOrNull
@@ -447,7 +425,6 @@ abstract class ComposeScreen(
             LOGGER.warn("Compose warm-up failed; the first open will build the UI instead", t)
             return false
         }
-        // the warm-up drew a frame the player never saw, so the first real open must draw its own
         sceneDirty = true
         if (prewarmCursor < frames) return false
         prewarmCursor = 0
@@ -507,12 +484,6 @@ abstract class ComposeScreen(
         }
     }
 
-    /**
-     * whether this screen keeps its scene so a later open can reuse it
-     *
-     * composing, laying out and drawing is most of what an open costs, and all three are skipped
-     * when the composition is still there. screens built for one target should leave this false.
-     */
     protected open val retainsScene: Boolean get() = false
 
     private fun disposeScene() {
@@ -520,7 +491,6 @@ abstract class ComposeScreen(
         closeSceneQuietly()
     }
 
-    /** Stops driving the scene without destroying it, so its composition survives to the next open */
     private fun releaseScene() {
         if (!retainsScene || sceneOrNull == null || scenePoisoned) {
             disposeScene()
@@ -587,8 +557,6 @@ abstract class ComposeScreen(
         }
 
         val debugOverlayOnTop = org.polyfrost.oneconfig.internal.ui.hud.DebugOverlayOffscreen.shouldSuppressVanilla()
-        // closing cleared the compose frame, so a real render has to re-arm the pipeline before a
-        // cached blit means anything, or it blits nothing at all
         if (renderMode == RenderMode.ON_DEMAND && !sceneDirty && !awaitingFirstFrame &&
             SkiaCtx.isDeferredComposeBackend && !debugOverlayOnTop
         ) {
@@ -614,8 +582,6 @@ abstract class ComposeScreen(
                     val recomposer = recomposerOrNull
                     val scope = renderScopeOrNull
                     val composeCanvas = canvas.asComposeCanvas()
-                    // frameNanos(), not the wall clock: the warm-up runs this scene's clock ahead in
-                    // big steps, and handing back a smaller number would walk every animation backwards
                     val rendered = if (recomposer == null || scope == null) null else withScene {
                         with(scope) { it.render(recomposer, composeCanvas, frameNanos()) }
                     }
@@ -630,8 +596,6 @@ abstract class ComposeScreen(
             }
         }
 
-        // the first frame of an open always submits, so SkiaCtx re-arms the compose frame that
-        // closing cleared; after that a reused composition is only redrawn when something changed
         val wasDirty = sceneDirty || awaitingFirstFrame || renderMode == RenderMode.CONTINUOUS
         sceneDirty = false
         awaitingFirstFrame = false
@@ -934,7 +898,6 @@ abstract class ComposeScreen(
     private companion object {
         const val SETTLE_FRAMES = 4
 
-        /** Long enough that one warm-up frame runs any of the interface's animations to the end */
         const val PREWARM_FRAME_NANOS = 500_000_000L
 
         const val MAX_SCENE_REBUILDS = 3

--- a/minecraft/src/main/kotlin/org/polyfrost/oneconfig/internal/ui/compose/ComposeScreen.kt
+++ b/minecraft/src/main/kotlin/org/polyfrost/oneconfig/internal/ui/compose/ComposeScreen.kt
@@ -197,6 +197,7 @@ abstract class ComposeScreen(
     }
 
     private fun closeSceneQuietly() {
+        releasePrewarmSurface()
         val scene = sceneOrNull
         val recomposer = recomposerOrNull
         if (scene == null && recomposer == null) return
@@ -353,6 +354,37 @@ abstract class ComposeScreen(
     // window or mod list starts over rather than reporting itself already done
     private var prewarmCursor = 0
 
+    private var prewarmSurfaceOrNull: Surface? = null
+    private var prewarmSurfaceW = 0
+    private var prewarmSurfaceH = 0
+
+    /** one surface for the whole pass: it is viewport sized and was being rebuilt on every frame */
+    private fun prewarmSurface(): Surface? {
+        prewarmSurfaceOrNull?.let { if (prewarmSurfaceW == lastSceneW && prewarmSurfaceH == lastSceneH) return it }
+        releasePrewarmSurface()
+        return try {
+            Surface.makeRenderTarget(
+                SkiaCtx.directContext,
+                false,
+                ImageInfo.makeN32Premul(lastSceneW, lastSceneH),
+            ).also {
+                prewarmSurfaceOrNull = it
+                prewarmSurfaceW = lastSceneW
+                prewarmSurfaceH = lastSceneH
+            }
+        } catch (t: Throwable) {
+            LOGGER.debug("Compose warm-up could not allocate a surface", t)
+            null
+        }
+    }
+
+    private fun releasePrewarmSurface() {
+        prewarmSurfaceOrNull?.let { runCatching { it.close() } }
+        prewarmSurfaceOrNull = null
+        prewarmSurfaceW = 0
+        prewarmSurfaceH = 0
+    }
+
     /**
      * builds the scene and renders it offscreen before anything asks to see it
      *
@@ -371,19 +403,16 @@ abstract class ComposeScreen(
             closeSceneQuietly()
             return false
         }
+        val hadContent = contentSet
         if (!bindContent()) {
             LOGGER.warn("{} warm-up: setContent did not take (poisoned={})", name, scenePoisoned)
             closeSceneQuietly()
             return false
         }
-        val surface = try {
-            Surface.makeRenderTarget(
-                SkiaCtx.directContext,
-                false,
-                ImageInfo.makeN32Premul(lastSceneW, lastSceneH),
-            )
-        } catch (t: Throwable) {
-            LOGGER.debug("Compose warm-up could not allocate a surface", t)
+        // setContent builds the whole composition, and rendering it on the same frame made one
+        // 2430 ms frame on the title screen. it gets a frame to itself
+        if (!hadContent) return false
+        val surface = prewarmSurface() ?: run {
             closeSceneQuietly()
             return false
         }
@@ -407,16 +436,16 @@ abstract class ComposeScreen(
             surface.flushAndSubmit()
         } catch (t: Throwable) {
             prewarmCursor = 0
+            releasePrewarmSurface()
             closeSceneQuietly()
             LOGGER.warn("Compose warm-up failed; the first open will build the UI instead", t)
             return false
-        } finally {
-            surface.close()
         }
         // the warm-up drew a frame the player never saw, so the first real open must draw its own
         sceneDirty = true
         if (prewarmCursor < frames) return false
         prewarmCursor = 0
+        releasePrewarmSurface()
         return true
     }
 

--- a/minecraft/src/main/kotlin/org/polyfrost/oneconfig/internal/ui/compose/ComposeScreen.kt
+++ b/minecraft/src/main/kotlin/org/polyfrost/oneconfig/internal/ui/compose/ComposeScreen.kt
@@ -32,8 +32,10 @@ import net.minecraft.client.input.KeyEvent as McKeyEvent
 //? }
 import net.minecraft.network.chat.CommonComponents
 import org.jetbrains.skia.FilterTileMode
+import org.jetbrains.skia.ImageInfo
 import org.jetbrains.skia.ImageFilter
 import org.jetbrains.skia.Paint
+import org.jetbrains.skia.Surface
 //? if < 26.3
 import org.lwjgl.glfw.GLFW
 //? if >= 26.3 {
@@ -238,8 +240,21 @@ abstract class ComposeScreen(
         return scene
     }
 
+    /**
+     * How far this scene's clock has been pushed ahead of the wall clock
+     *
+     * A warm-up runs animations forward in big steps, and holding that as an offset is what stops
+     * the next real frame handing back a smaller number and walking every Transition backwards.
+     */
+    private var clockSkewNanos = 0L
+
+    private fun frameNanos(): Long = System.nanoTime() + clockSkewNanos
+
     @Volatile
     private var sceneDirty = true
+
+    /** Set by [init]; the frame it guards re-arms the compose pipeline that closing cleared */
+    private var awaitingFirstFrame = false
 
     private var lastPointer: Offset? = null
     private var lastSceneW = -1
@@ -309,13 +324,16 @@ abstract class ComposeScreen(
     }
 
     override fun init() {
+        val hadScene = sceneOrNull != null
         val scene = ensureScene()
         if (scene == null) {
             reportUnavailableAndClose()
             return
         }
-
-        sceneDirty = true
+        // a reused scene still holds its composition and its last frame, so the cached blit below
+        // can serve the open. anything that really differs invalidates and sets this again
+        if (!hadScene) sceneDirty = true
+        awaitingFirstFrame = true
         lastPointer = null
 
         syncSceneMetrics()
@@ -327,7 +345,79 @@ abstract class ComposeScreen(
 
         if (!bindContent()) {
             closeWithMessage("OneConfig's UI failed to start. Please check your logs and report this.")
+            return
         }
+    }
+
+    // how far the last call got. reset on completion, so a warm-up running again against a changed
+    // window or mod list starts over rather than reporting itself already done
+    private var prewarmCursor = 0
+
+    /**
+     * builds the scene and renders it offscreen before anything asks to see it
+     *
+     * [step] runs before each frame so the caller can drive state across them, and frame times are
+     * advanced by hand so an animation finishes in one frame. false means nothing was kept.
+     */
+    protected fun prewarm(frames: Int, budget: Int = frames, step: (Int) -> Unit): Boolean {
+        val name = this::class.java.simpleName
+        if (ensureScene() == null) {
+            LOGGER.warn("{} warm-up: no scene ({})", name, ComposeSupport.unavailableReason() ?: "createScene failed")
+            return false
+        }
+        syncSceneMetrics()
+        if (lastSceneW <= 0 || lastSceneH <= 0) {
+            LOGGER.warn("{} warm-up: window is {}x{}", name, lastSceneW, lastSceneH)
+            closeSceneQuietly()
+            return false
+        }
+        if (!bindContent()) {
+            LOGGER.warn("{} warm-up: setContent did not take (poisoned={})", name, scenePoisoned)
+            closeSceneQuietly()
+            return false
+        }
+        val surface = try {
+            Surface.makeRenderTarget(
+                SkiaCtx.directContext,
+                false,
+                ImageInfo.makeN32Premul(lastSceneW, lastSceneH),
+            )
+        } catch (t: Throwable) {
+            LOGGER.debug("Compose warm-up could not allocate a surface", t)
+            closeSceneQuietly()
+            return false
+        }
+        try {
+            val canvas = surface.canvas.asComposeCanvas()
+            // only as many as the caller allowed: running all of them in one go put the whole
+            // warm-up on a single frame, which was measured at 1332 ms as the world appeared
+            val until = minOf(frames, prewarmCursor + budget.coerceAtLeast(1))
+            val recomposer = recomposerOrNull
+            val scope = renderScopeOrNull
+            if (recomposer == null || scope == null) {
+                closeSceneQuietly()
+                return false
+            }
+            while (prewarmCursor < until) {
+                step(prewarmCursor)
+                withScene { with(scope) { it.render(recomposer, canvas, frameNanos()) } }
+                clockSkewNanos += PREWARM_FRAME_NANOS
+                prewarmCursor++
+            }
+            surface.flushAndSubmit()
+        } catch (t: Throwable) {
+            prewarmCursor = 0
+            closeSceneQuietly()
+            LOGGER.warn("Compose warm-up failed; the first open will build the UI instead", t)
+            return false
+        } finally {
+            surface.close()
+        }
+        // the warm-up drew a frame the player never saw, so the first real open must draw its own
+        sceneDirty = true
+        if (prewarmCursor < frames) return false
+        prewarmCursor = 0
+        return true
     }
 
     private fun bindContent(): Boolean {
@@ -382,19 +472,36 @@ abstract class ComposeScreen(
         }
     }
 
+    /**
+     * whether this screen keeps its scene so a later open can reuse it
+     *
+     * composing, laying out and drawing is most of what an open costs, and all three are skipped
+     * when the composition is still there. screens built for one target should leave this false.
+     */
+    protected open val retainsScene: Boolean get() = false
+
     private fun disposeScene() {
         SkiaCtx.clearComposeFrame()
         closeSceneQuietly()
     }
 
+    /** Stops driving the scene without destroying it, so its composition survives to the next open */
+    private fun releaseScene() {
+        if (!retainsScene || sceneOrNull == null || scenePoisoned) {
+            disposeScene()
+            return
+        }
+        SkiaCtx.clearComposeFrame()
+    }
+
     override fun onClose() {
         ComposeSceneContextImpl.resetPointerIcon()
-        disposeScene()
+        releaseScene()
     }
 
     override fun removed() {
         ComposeSceneContextImpl.resetPointerIcon()
-        disposeScene()
+        releaseScene()
         super.removed()
     }
 
@@ -445,7 +552,11 @@ abstract class ComposeScreen(
         }
 
         val debugOverlayOnTop = org.polyfrost.oneconfig.internal.ui.hud.DebugOverlayOffscreen.shouldSuppressVanilla()
-        if (renderMode == RenderMode.ON_DEMAND && !sceneDirty && SkiaCtx.isDeferredComposeBackend && !debugOverlayOnTop) {
+        // closing cleared the compose frame, so a real render has to re-arm the pipeline before a
+        // cached blit means anything, or it blits nothing at all
+        if (renderMode == RenderMode.ON_DEMAND && !sceneDirty && !awaitingFirstFrame &&
+            SkiaCtx.isDeferredComposeBackend && !debugOverlayOnTop
+        ) {
             if (SkiaCtx.blitComposeCached(ctx)) return
         }
 
@@ -468,8 +579,10 @@ abstract class ComposeScreen(
                     val recomposer = recomposerOrNull
                     val scope = renderScopeOrNull
                     val composeCanvas = canvas.asComposeCanvas()
+                    // frameNanos(), not the wall clock: the warm-up runs this scene's clock ahead in
+                    // big steps, and handing back a smaller number would walk every animation backwards
                     val rendered = if (recomposer == null || scope == null) null else withScene {
-                        with(scope) { it.render(recomposer, composeCanvas, System.nanoTime()) }
+                        with(scope) { it.render(recomposer, composeCanvas, frameNanos()) }
                     }
                     if (rendered != null) {
                         sceneRebuilds = 0
@@ -482,8 +595,11 @@ abstract class ComposeScreen(
             }
         }
 
-        val wasDirty = sceneDirty || renderMode == RenderMode.CONTINUOUS
+        // the first frame of an open always submits, so SkiaCtx re-arms the compose frame that
+        // closing cleared; after that a reused composition is only redrawn when something changed
+        val wasDirty = sceneDirty || awaitingFirstFrame || renderMode == RenderMode.CONTINUOUS
         sceneDirty = false
+        awaitingFirstFrame = false
         when {
             SkiaCtx.isDeferredComposeBackend -> SkiaCtx.drawComposeBlit(ctx, renderBlock)
             SkiaCtx.isVulkanMode -> SkiaCtx.queueDraw(renderBlock) // non-deferred Vulkan draws straight to the main RT
@@ -782,6 +898,9 @@ abstract class ComposeScreen(
 
     private companion object {
         const val SETTLE_FRAMES = 4
+
+        /** Long enough that one warm-up frame runs any of the interface's animations to the end */
+        const val PREWARM_FRAME_NANOS = 500_000_000L
 
         const val MAX_SCENE_REBUILDS = 3
 

--- a/minecraft/src/main/kotlin/org/polyfrost/oneconfig/internal/ui/compose/SkiaCtx.kt
+++ b/minecraft/src/main/kotlin/org/polyfrost/oneconfig/internal/ui/compose/SkiaCtx.kt
@@ -492,11 +492,12 @@ object SkiaCtx {
         if (clearComposeAfterDraw && !composeStandsInForHud) finishComposeClear()
         *///? }
         runWarmups()
-        val draws = queuedDraws.toList()
-        queuedDraws.clear()
         val notifDraw = if (NotificationsManager.count > 0) notifRender else null
         val wantCompose = composeActive && !isVulkanMode
-        if (draws.isEmpty() && notifDraw == null && !wantCompose) return
+        // tested before the snapshot is taken, so an idle frame costs nothing rather than a list copy
+        if (queuedDraws.isEmpty() && notifDraw == null && !wantCompose) return
+        val draws = queuedDraws.toList()
+        queuedDraws.clear()
 
         val mainSurface = if (isVulkanMode) resolveVkSurface() else resolveGLSurface()
         if (mainSurface == null) return

--- a/minecraft/src/main/kotlin/org/polyfrost/oneconfig/internal/ui/compose/SkiaCtx.kt
+++ b/minecraft/src/main/kotlin/org/polyfrost/oneconfig/internal/ui/compose/SkiaCtx.kt
@@ -494,7 +494,6 @@ object SkiaCtx {
         runWarmups()
         val notifDraw = if (NotificationsManager.count > 0) notifRender else null
         val wantCompose = composeActive && !isVulkanMode
-        // tested before the snapshot is taken, so an idle frame costs nothing rather than a list copy
         if (queuedDraws.isEmpty() && notifDraw == null && !wantCompose) return
         val draws = queuedDraws.toList()
         queuedDraws.clear()

--- a/minecraft/src/main/kotlin/org/polyfrost/oneconfig/internal/ui/compose/impls/HudEditorUIScreen.kt
+++ b/minecraft/src/main/kotlin/org/polyfrost/oneconfig/internal/ui/compose/impls/HudEditorUIScreen.kt
@@ -53,6 +53,11 @@ class HudEditorUIScreen private constructor() : ComposeScreen() {
          */
         @JvmStatic
         fun prewarmShared(): Boolean = open().runPrewarm()
+
+        @JvmStatic
+        fun endPrewarmShared() {
+            instance?.endPrewarm()
+        }
     }
 
     /** Set the first time the editor is really shown, after which no warm-up may touch its scene */
@@ -143,7 +148,7 @@ class HudEditorUIScreen private constructor() : ComposeScreen() {
                 requestCloseCallback?.invoke()
             } else {
                 returningToOneConfig = true
-                Platform.screen().display(OneConfigUIScreen.open())
+                Platform.screen().display(OneConfigUIScreen.resume())
             }
             return true
         }
@@ -209,7 +214,7 @@ class HudEditorUIScreen private constructor() : ComposeScreen() {
                     HudDesignStudio(
                         onReturnToOneConfig = {
                             returningToOneConfig = true
-                            Platform.screen().display(OneConfigUIScreen.open())
+                            Platform.screen().display(OneConfigUIScreen.resume())
                         }
                     )
                 }

--- a/minecraft/src/main/kotlin/org/polyfrost/oneconfig/internal/ui/compose/impls/HudEditorUIScreen.kt
+++ b/minecraft/src/main/kotlin/org/polyfrost/oneconfig/internal/ui/compose/impls/HudEditorUIScreen.kt
@@ -1,14 +1,8 @@
 package org.polyfrost.oneconfig.internal.ui.compose.impls
 
-import androidx.compose.animation.AnimatedVisibility
-import androidx.compose.animation.ExitTransition
 import androidx.compose.animation.core.EaseIn
 import androidx.compose.animation.core.EaseOutCubic
 import androidx.compose.animation.core.tween
-import androidx.compose.animation.fadeIn
-import androidx.compose.animation.fadeOut
-import androidx.compose.animation.scaleIn
-import androidx.compose.animation.scaleOut
 import androidx.compose.foundation.layout.*
 import androidx.compose.runtime.*
 import androidx.compose.ui.Modifier
@@ -20,6 +14,7 @@ import org.polyfrost.oneconfig.api.hud.v1.HudManager
 import org.polyfrost.oneconfig.api.platform.v1.Platform
 import org.polyfrost.oneconfig.internal.OneConfigConfig
 import org.polyfrost.oneconfig.internal.ui.compose.ComposeScreen
+import org.polyfrost.oneconfig.internal.ui.components.RetainedVisibility
 import org.polyfrost.oneconfig.internal.ui.guiCloseAnimationMillis
 import org.polyfrost.oneconfig.internal.ui.keybind.KeybindRecordingBus
 import org.polyfrost.oneconfig.internal.ui.hud.screens.HudDesignStudio
@@ -32,7 +27,49 @@ import org.polyfrost.oneconfig.internal.ui.sound.UiSoundEvent
 import org.polyfrost.oneconfig.internal.ui.sound.UiSounds
 import org.polyfrost.oneconfig.internal.ui.themes.Theme
 
-class HudEditorUIScreen : ComposeScreen() {
+private val LOGGER = org.apache.logging.log4j.LogManager.getLogger("OneConfig/HudEditor")
+
+/** One frame to build it, one to settle whatever that frame scheduled */
+private const val PREWARM_FRAMES = 2
+
+class HudEditorUIScreen private constructor() : ComposeScreen() {
+    companion object {
+        /**
+         * The editor screen, reused so its scene and composition outlive a close
+         *
+         * Building it is the most expensive open OneConfig has: forty HUD previews, each its own
+         * compose runtime. There is only ever one editor, so there is only ever one of these.
+         */
+        private var instance: HudEditorUIScreen? = null
+
+        @JvmStatic
+        fun open(): HudEditorUIScreen = instance ?: HudEditorUIScreen().also { instance = it }
+
+        /**
+         * Composes, lays out and draws the editor before anything opens it
+         *
+         * Unlike the config screen this never raises the interface's visibility. [RetainedVisibility]
+         * composes its content either way, so the expensive half happens with no state moved.
+         */
+        @JvmStatic
+        fun prewarmShared(): Boolean = open().runPrewarm()
+    }
+
+    /** Set the first time the editor is really shown, after which no warm-up may touch its scene */
+    @Volatile private var everOpened = false
+
+    private fun runPrewarm(): Boolean {
+        if (everOpened || Platform.screen().current<Any?>() === this) return true
+        return try {
+            prewarm(PREWARM_FRAMES) { }
+        } catch (t: Throwable) {
+            LOGGER.warn("HUD editor warm-up failed; the first open will build it instead", t)
+            false
+        }
+    }
+
+    override val retainsScene: Boolean get() = true
+
     @Volatile private var closeRequested = false
     @Volatile private var closeRequestedAt = 0L
     @Volatile private var closeAnimationMs = 0L
@@ -61,8 +98,16 @@ class HudEditorUIScreen : ComposeScreen() {
     override val scrollSpeed: Float get() = 0.5f
 
     override fun init() {
+        everOpened = true
+        // a reused screen still carries the close it was last dismissed by, and its interface still
+        // has the visibility that close lowered; both have to be put back before the first frame
+        closeRequested = false
+        closeRequestedAt = 0L
+        closeAnimationMs = 0L
+        returningToOneConfig = false
         UiSounds.acquireAmbience()
         super.init()
+        requestOpenCallback?.invoke()
     }
 
     override fun removed() {
@@ -95,7 +140,7 @@ class HudEditorUIScreen : ComposeScreen() {
                 requestCloseCallback?.invoke()
             } else {
                 returningToOneConfig = true
-                Platform.screen().display(OneConfigUIScreen())
+                Platform.screen().display(OneConfigUIScreen.open())
             }
             return true
         }
@@ -145,27 +190,25 @@ class HudEditorUIScreen : ComposeScreen() {
             requestOpenCallback = requestOpen
         }
 
-        val exitMs = guiCloseAnimationMillis().toInt()
-        AnimatedVisibility(
+        val exitMs = guiCloseAnimationMillis().toInt().coerceAtLeast(1)
+        RetainedVisibility(
             visible = visible,
-            enter = fadeIn(tween(200, easing = EaseOutCubic)) + scaleIn(tween(200, easing = EaseOutCubic), initialScale = 0.92f),
-            exit = if (exitMs > 0)
-                fadeOut(tween(exitMs, easing = EaseIn)) + scaleOut(tween(exitMs, easing = EaseIn), targetScale = 0.92f)
-            else ExitTransition.None,
-        ) {
-            Box(Modifier.fillMaxSize()) {
-                CompositionLocalProvider(
-                    LocalLifecycleOwner provides Lifecycle,
-                    LocalViewModelStoreOwner provides OCViewModelStoreOwner
-                ) {
-                    Theme(pixelGrid = true) {
-                        HudDesignStudio(
-                            onReturnToOneConfig = {
-                                returningToOneConfig = true
-                                Platform.screen().display(OneConfigUIScreen())
-                            }
-                        )
-                    }
+            enter = tween(200, easing = EaseOutCubic),
+            exit = tween(exitMs, easing = EaseIn),
+            modifier = Modifier.fillMaxSize(),
+            hiddenScale = 0.92f,
+        ) { _ ->
+            CompositionLocalProvider(
+                LocalLifecycleOwner provides Lifecycle,
+                LocalViewModelStoreOwner provides OCViewModelStoreOwner
+            ) {
+                Theme(pixelGrid = true) {
+                    HudDesignStudio(
+                        onReturnToOneConfig = {
+                            returningToOneConfig = true
+                            Platform.screen().display(OneConfigUIScreen.open())
+                        }
+                    )
                 }
             }
         }

--- a/minecraft/src/main/kotlin/org/polyfrost/oneconfig/internal/ui/compose/impls/HudEditorUIScreen.kt
+++ b/minecraft/src/main/kotlin/org/polyfrost/oneconfig/internal/ui/compose/impls/HudEditorUIScreen.kt
@@ -29,28 +29,15 @@ import org.polyfrost.oneconfig.internal.ui.themes.Theme
 
 private val LOGGER = org.apache.logging.log4j.LogManager.getLogger("OneConfig/HudEditor")
 
-/** One frame to build it, one to settle whatever that frame scheduled */
 private const val PREWARM_FRAMES = 2
 
 class HudEditorUIScreen private constructor() : ComposeScreen() {
     companion object {
-        /**
-         * The editor screen, reused so its scene and composition outlive a close
-         *
-         * Building it is the most expensive open OneConfig has: forty HUD previews, each its own
-         * compose runtime. There is only ever one editor, so there is only ever one of these.
-         */
         private var instance: HudEditorUIScreen? = null
 
         @JvmStatic
         fun open(): HudEditorUIScreen = instance ?: HudEditorUIScreen().also { instance = it }
 
-        /**
-         * Composes, lays out and draws the editor before anything opens it
-         *
-         * Unlike the config screen this never raises the interface's visibility. [RetainedVisibility]
-         * composes its content either way, so the expensive half happens with no state moved.
-         */
         @JvmStatic
         fun prewarmShared(): Boolean = open().runPrewarm()
 
@@ -60,7 +47,6 @@ class HudEditorUIScreen private constructor() : ComposeScreen() {
         }
     }
 
-    /** Set the first time the editor is really shown, after which no warm-up may touch its scene */
     @Volatile private var everOpened = false
 
     private fun runPrewarm(): Boolean {
@@ -104,11 +90,7 @@ class HudEditorUIScreen private constructor() : ComposeScreen() {
 
     override fun init() {
         everOpened = true
-        // the composition outlives a close and the warm-up already ran its once-per-composition
-        // effects, so an open has to say so for anything left pending to be picked up
         HudManager.editorOpenRevision.intValue++
-        // a reused screen still carries the close it was last dismissed by, and its interface still
-        // has the visibility that close lowered; both have to be put back before the first frame
         closeRequested = false
         closeRequestedAt = 0L
         closeAnimationMs = 0L

--- a/minecraft/src/main/kotlin/org/polyfrost/oneconfig/internal/ui/compose/impls/HudEditorUIScreen.kt
+++ b/minecraft/src/main/kotlin/org/polyfrost/oneconfig/internal/ui/compose/impls/HudEditorUIScreen.kt
@@ -99,6 +99,9 @@ class HudEditorUIScreen private constructor() : ComposeScreen() {
 
     override fun init() {
         everOpened = true
+        // the composition outlives a close and the warm-up already ran its once-per-composition
+        // effects, so an open has to say so for anything left pending to be picked up
+        HudManager.editorOpenRevision.intValue++
         // a reused screen still carries the close it was last dismissed by, and its interface still
         // has the visibility that close lowered; both have to be put back before the first frame
         closeRequested = false

--- a/minecraft/src/main/kotlin/org/polyfrost/oneconfig/internal/ui/compose/impls/OneConfigUIScreen.kt
+++ b/minecraft/src/main/kotlin/org/polyfrost/oneconfig/internal/ui/compose/impls/OneConfigUIScreen.kt
@@ -52,13 +52,6 @@ class OneConfigUIScreen @JvmOverloads constructor(
     companion object {
         private val LOGGER = org.apache.logging.log4j.LogManager.getLogger("OneConfig/UI")
 
-        /**
-         * The general-purpose screen, reused so its Compose scene and composition outlive a close
-         *
-         * Composing, laying out and drawing the tree is nearly all of what an open costs, and a
-         * reused screen skips all three. A screen aimed at one mod's config is not shared: its page
-         * is fixed at construction, and there is nothing to come back to.
-         */
         private var sharedScreen: OneConfigUIScreen? = null
 
         private fun shared(): OneConfigUIScreen =
@@ -67,7 +60,6 @@ class OneConfigUIScreen @JvmOverloads constructor(
         @JvmStatic
         fun forRoute(route: Any?): OneConfigUIScreen = shared().also { it.initialRoute = route }
 
-        /** Opens the shared screen, reusing whatever it already has composed */
         @JvmStatic
         fun open(): OneConfigUIScreen = shared().also { it.initialRoute = null }
         @JvmStatic
@@ -85,17 +77,6 @@ class OneConfigUIScreen @JvmOverloads constructor(
 
         private val savePending = java.util.concurrent.atomic.AtomicBoolean(false)
 
-        /**
-         * Writes every registered tree, once, however many closes asked for it
-         *
-         * A save queued and not yet started will write whatever the next close would have written
-         * anyway, so asking again only makes the executor serialise a second full pass over every
-         * config file. Holding the open key produced dozens of closes a second and therefore dozens
-         * of whole-config writes queued behind each other.
-         *
-         * The flag clears as the save begins rather than when it ends, so a close that lands during
-         * a write still gets one of its own.
-         */
         private fun scheduleSave() {
             if (!savePending.compareAndSet(false, true)) return
             SAVE_EXECUTOR.execute {
@@ -132,12 +113,6 @@ class OneConfigUIScreen @JvmOverloads constructor(
             else -> OpeningRoute(ModsGraph)
         }
 
-        /**
-         * Composes, lays out and draws the shared screen before anything opens it
-         *
-         * Queued at client construction and run on the first Skia frame, which lands on the title
-         * screen: the cost of the first open is paid where nobody is waiting for a frame.
-         */
         @JvmStatic
         fun prewarmShared(): Boolean = shared().runPrewarm()
 
@@ -146,35 +121,25 @@ class OneConfigUIScreen @JvmOverloads constructor(
             sharedScreen?.endPrewarm()
         }
 
-        // one at a time: a warm-up frame is not cheap and nothing waits on it finishing, and two
-        // per real frame was measured at 919 ms over 11 frames
         private const val PREWARM_FRAME_BUDGET = 1
 
         private const val PREWARM_OPEN_FRAME = 1
 
-        // focusing the search field lays out a paragraph, which loads the whole Skia text stack.
-        // measured at 40 ms on the frame the interface opened, whenever instant search is on
         private const val PREWARM_FOCUS_FRAME = 2
 
-        // an icon is only rasterised when its card is first drawn, so the grid is dragged through
-        // its whole extent here to make the first real scroll free
         private val PREWARM_SCROLL_FRAMES = 5..17
         private const val PREWARM_RESTORE_FRAME = 18
 
-        // every page the sidebar reaches, two frames each: one to navigate, one to lay out
         private val PREWARM_ROUTES = listOf(PreferencesGraph, ThemesGraph, KeybindsGraph, ModsGraph)
         private const val PREWARM_FRAMES_PER_PAGE = 2
         private val PREWARM_PAGE_FRAMES = PREWARM_RESTORE_FRAME + 1..
             PREWARM_RESTORE_FRAME + PREWARM_ROUTES.size * PREWARM_FRAMES_PER_PAGE
 
-        /** the tour is not history the player took, so it is not left in the back stack */
         private val PREWARM_FORGET_FRAME = PREWARM_PAGE_FRAMES.last + 1
         private val PREWARM_CLOSE_FRAME = PREWARM_FORGET_FRAME + 1
 
-        // the schedule above decides this, so adding a route cannot leave the tail behind
         private val PREWARM_FRAMES = PREWARM_CLOSE_FRAME + 1
 
-        /** The key the mod grid remembers its scroll position under */
         private const val MOD_GRID_KEY = "mods"
 
         @JvmStatic
@@ -212,9 +177,6 @@ class OneConfigUIScreen @JvmOverloads constructor(
         return true
     }
 
-    // snapshot state rather than plain fields: a composition that outlives an open has to notice
-    // these change, and recompose only the part that reads them rather than everything
-
     /** The page this screen is showing which survives the scene being disposed and rebuilt */
     private var route: Any? by mutableStateOf(null)
 
@@ -228,31 +190,22 @@ class OneConfigUIScreen @JvmOverloads constructor(
 
     private var openRevision by mutableIntStateOf(0)
 
-    /** Set while [prewarmShared] drives the composition, so warming up cannot close or make a sound */
     private var prewarming = false
 
-    /** Set the first time the screen is really shown, after which no warm-up may touch its scene */
     @Volatile private var everOpened = false
 
     private fun runPrewarm(): Boolean {
-        // a warm-up runs the clock forward and toggles visibility, which is only safe on a tree
-        // nobody has used: once shown, it carries state a warm-up has no business moving
         if (everOpened || Platform.screen().current<Any?>() === this) return true
         prewarming = true
         return try {
             ConfigRegistry.loadFrom(ConfigManager.active(), ConfigSource.OC)
-            // every card the UI can show, and both the grid and the editor's library scale with
-            // the pack, so both were resolving icons inline on the frame that first drew them
             warmIconCache(ConfigRegistry.modCardConfigs.mapNotNull { it.icon })
             var restoreTo = 0
             prewarm(PREWARM_FRAMES, PREWARM_FRAME_BUDGET) { frame ->
-                // the interface raises its own visibility from a once-per-composition effect, so
-                // later passes ask; lowering it again leaves exactly what a close leaves behind
                 when (frame) {
                     PREWARM_OPEN_FRAME -> requestOpenCallback?.invoke()
                     PREWARM_FOCUS_FRAME -> ShellState.focusSearchField = true
                     PREWARM_CLOSE_FRAME -> {
-                        // the warm-up focused the field; a real open decides that for itself
                         ShellState.focusSearchField = false
                         ShellState.searchFieldFocused = false
                         ShellState.searchQuery = ""
@@ -260,8 +213,6 @@ class OneConfigUIScreen @JvmOverloads constructor(
                     }
                     PREWARM_RESTORE_FRAME -> scrollModGrid(restoreTo)
                     in PREWARM_PAGE_FRAMES -> {
-                        // a page nobody has visited has never been composed, so the first visit pays
-                        // for all of it on the frame it lands: 171 ms for preferences, 37 to 55 for the rest
                         val step = frame - PREWARM_PAGE_FRAMES.first
                         if (step % PREWARM_FRAMES_PER_PAGE == 0) {
                             warmRoute(PREWARM_ROUTES[step / PREWARM_FRAMES_PER_PAGE])
@@ -286,12 +237,10 @@ class OneConfigUIScreen @JvmOverloads constructor(
         }
     }
 
-    /** The grid is only there once the mod page has composed, and only it knows how far it can go */
     private fun scrollModGrid(index: Int) {
         runCatching { ShellState.gridStates[MOD_GRID_KEY]?.requestScrollToItem(index) }
     }
 
-    /** The nav host only exists once the shell has composed, so a warm-up asks rather than assumes */
     private fun warmRoute(route: Any) {
         runCatching { if (LocalNavController.isReady) LocalNavController.wrapper.navigate(route) }
     }
@@ -305,8 +254,6 @@ class OneConfigUIScreen @JvmOverloads constructor(
         ConfigRegistry.loadFrom(ConfigManager.active(), ConfigSource.OC)
         initialTree?.let { ConfigRegistry.registerTree(it, ConfigSource.OC) }
 
-        // resolved on every open so opening behaviour still applies to a reused screen. writing the
-        // same value back is free: snapshot state only records a write that changes something
         val isResume = resumeNext
         resumeNext = false
         val (target, targetRestoring) = when {
@@ -370,8 +317,6 @@ class OneConfigUIScreen @JvmOverloads constructor(
         HudManager.overrideShowInScreens = true
         HudManager.isConfigUiOpen = true
 
-        // a reused screen still carries the close it was dismissed by, and left set the opening
-        // frame computes a finished closing animation and renders fully faded out
         closeRequested = false
         closeRequestedAt = 0L
         closeAnimationMs = 0L
@@ -382,8 +327,6 @@ class OneConfigUIScreen @JvmOverloads constructor(
         UiSounds.acquireAmbience()
         super.init()
 
-        // the interface raises its visibility from a LaunchedEffect(Unit), so a composition that
-        // outlives a close comes back invisible. ask it to open, exactly as cancelClose does
         requestOpenCallback?.invoke()
     }
 
@@ -402,11 +345,7 @@ class OneConfigUIScreen @JvmOverloads constructor(
         SkiaCtx.suppressInGameHudRender = false
         HudManager.overrideShowInScreens = false
         HudManager.isConfigUiOpen = false
-        // the shell is no longer laid out but its last bounds would still answer hit tests, and the
-        // HUD editor asks them to decide what a click is over
         ShellState.shellBounds = null
-        // the offscreen targets stay alive across opens: resolveTarget rebuilds them when the
-        // viewport changes, so releasing them here only made the next open pay for fresh ones
         UiSounds.releaseAmbience()
         // writing every registered tree hitches and Minecraft only re-grabs the cursor once this returns
         scheduleSave()

--- a/minecraft/src/main/kotlin/org/polyfrost/oneconfig/internal/ui/compose/impls/OneConfigUIScreen.kt
+++ b/minecraft/src/main/kotlin/org/polyfrost/oneconfig/internal/ui/compose/impls/OneConfigUIScreen.kt
@@ -2,6 +2,7 @@ package org.polyfrost.oneconfig.internal.ui.compose.impls
 
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.platform.LocalWindowInfo
@@ -46,8 +47,7 @@ class OneConfigUIScreen @JvmOverloads constructor(
 ) : ComposeScreen() {
     private var initialRoute: Any? = null
 
-    /** Only the shared screen is worth keeping: a per-mod one opens on a page fixed at construction */
-    override val retainsScene: Boolean get() = initialTreeId == null && initialTree == null
+    override val retainsScene: Boolean get() = this === sharedScreen
 
     companion object {
         private val LOGGER = org.apache.logging.log4j.LogManager.getLogger("OneConfig/UI")
@@ -70,6 +70,11 @@ class OneConfigUIScreen @JvmOverloads constructor(
         /** Opens the shared screen, reusing whatever it already has composed */
         @JvmStatic
         fun open(): OneConfigUIScreen = shared().also { it.initialRoute = null }
+        @JvmStatic
+        fun resume(): OneConfigUIScreen = shared().also {
+            it.initialRoute = null
+            it.resumeNext = true
+        }
         private const val FULLSCREEN_BLUR_RADIUS = 8f
         private const val OPEN_ANIMATION_MS = 250L
 
@@ -135,6 +140,11 @@ class OneConfigUIScreen @JvmOverloads constructor(
          */
         @JvmStatic
         fun prewarmShared(): Boolean = shared().runPrewarm()
+
+        @JvmStatic
+        fun endPrewarmShared() {
+            sharedScreen?.endPrewarm()
+        }
 
         // one at a time: a warm-up frame is not cheap and nothing waits on it finishing, and two
         // per real frame was measured at 919 ms over 11 frames
@@ -213,6 +223,10 @@ class OneConfigUIScreen @JvmOverloads constructor(
 
     /** True when [route] is a page being put back rather than a page being opened */
     private var restoring by mutableStateOf(false)
+
+    private var resumeNext = false
+
+    private var openRevision by mutableIntStateOf(0)
 
     /** Set while [prewarmShared] drives the composition, so warming up cannot close or make a sound */
     private var prewarming = false
@@ -293,9 +307,12 @@ class OneConfigUIScreen @JvmOverloads constructor(
 
         // resolved on every open so opening behaviour still applies to a reused screen. writing the
         // same value back is free: snapshot state only records a write that changes something
+        val isResume = resumeNext
+        resumeNext = false
         val (target, targetRestoring) = when {
-            initialRoute != null -> initialRoute to restoring
-            initialTreeId != null -> ModConfigRoute(initialTreeId, initialCategory) to restoring
+            isResume -> (ShellState.lastRoute?.takeIf { it !== HudEditorRoute } ?: ModsGraph) to true
+            initialRoute != null -> initialRoute to false
+            initialTreeId != null -> ModConfigRoute(initialTreeId, initialCategory) to false
             else -> {
                 val opening = resolveOpeningBehaviorRoute()
                 val resolved = opening.route.takeIf { it !== HudEditorRoute } ?: ModsGraph
@@ -304,6 +321,8 @@ class OneConfigUIScreen @JvmOverloads constructor(
         }
         route = target
         restoring = targetRestoring
+        resuming = isResume
+        openRevision++
         ShellState.lastRoute = target
 
         try {
@@ -380,11 +399,6 @@ class OneConfigUIScreen @JvmOverloads constructor(
     }
 
     override fun removed() {
-        // a screen opened over this one removes it and hands it back on close with the scene rebuilt
-        // in between so the page has to be carried across by hand
-        ShellState.lastRoute?.takeIf { it !== HudEditorRoute }?.let { route = it }
-        resuming = true
-        restoring = true
         SkiaCtx.suppressInGameHudRender = false
         HudManager.overrideShowInScreens = false
         HudManager.isConfigUiOpen = false
@@ -523,6 +537,7 @@ class OneConfigUIScreen @JvmOverloads constructor(
             initialRoute = initialRoute,
             resuming = resuming,
             restoring = restoring,
+            openRevision = openRevision,
             onCloseRequest = { beginClose() },
             onCloseReady = { closeRequest ->
                 requestCloseCallback = closeRequest

--- a/minecraft/src/main/kotlin/org/polyfrost/oneconfig/internal/ui/compose/impls/OneConfigUIScreen.kt
+++ b/minecraft/src/main/kotlin/org/polyfrost/oneconfig/internal/ui/compose/impls/OneConfigUIScreen.kt
@@ -1,6 +1,9 @@
 package org.polyfrost.oneconfig.internal.ui.compose.impls
 
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.platform.LocalWindowInfo
 import com.mojang.blaze3d.platform.InputConstants
 import net.minecraft.client.gui.GuiGraphicsExtractor
@@ -14,13 +17,16 @@ import org.polyfrost.oneconfig.internal.ui.keybind.KeybindRecordingBus
 import org.polyfrost.oneconfig.internal.ui.api.ConfigRegistry
 import org.polyfrost.oneconfig.internal.ui.api.ConfigSource
 import org.polyfrost.oneconfig.internal.ui.OneConfigInterface
+import org.polyfrost.oneconfig.internal.ui.components.warmIconCache
 import org.polyfrost.oneconfig.internal.ui.guiCloseAnimationMillis
 import org.polyfrost.oneconfig.internal.ui.compose.BlurRenderer
 import org.polyfrost.oneconfig.internal.ui.compose.ComposeScreen
 import org.polyfrost.oneconfig.internal.ui.compose.SkiaCtx
 import org.polyfrost.oneconfig.internal.ui.navigation.graph.ModConfigRoute
 import org.polyfrost.oneconfig.internal.ui.navigation.graph.ModsGraph
+import org.polyfrost.oneconfig.internal.ui.navigation.graph.KeybindsGraph
 import org.polyfrost.oneconfig.internal.ui.navigation.graph.PreferencesGraph
+import org.polyfrost.oneconfig.internal.ui.navigation.graph.ThemesGraph
 import org.polyfrost.oneconfig.internal.ui.hud.screens.HudDesignSession
 import org.polyfrost.oneconfig.internal.ui.hud.screens.HudEditorViewport
 import org.polyfrost.oneconfig.internal.ui.PlayerHeadLoader
@@ -40,18 +46,61 @@ class OneConfigUIScreen @JvmOverloads constructor(
 ) : ComposeScreen() {
     private var initialRoute: Any? = null
 
+    /** Only the shared screen is worth keeping: a per-mod one opens on a page fixed at construction */
+    override val retainsScene: Boolean get() = initialTreeId == null && initialTree == null
+
     companion object {
         private val LOGGER = org.apache.logging.log4j.LogManager.getLogger("OneConfig/UI")
 
+        /**
+         * The general-purpose screen, reused so its Compose scene and composition outlive a close
+         *
+         * Composing, laying out and drawing the tree is nearly all of what an open costs, and a
+         * reused screen skips all three. A screen aimed at one mod's config is not shared: its page
+         * is fixed at construction, and there is nothing to come back to.
+         */
+        private var sharedScreen: OneConfigUIScreen? = null
+
+        private fun shared(): OneConfigUIScreen =
+            sharedScreen ?: OneConfigUIScreen().also { sharedScreen = it }
+
         @JvmStatic
-        fun forRoute(route: Any?): OneConfigUIScreen =
-            OneConfigUIScreen().also { it.initialRoute = route }
+        fun forRoute(route: Any?): OneConfigUIScreen = shared().also { it.initialRoute = route }
+
+        /** Opens the shared screen, reusing whatever it already has composed */
+        @JvmStatic
+        fun open(): OneConfigUIScreen = shared().also { it.initialRoute = null }
         private const val FULLSCREEN_BLUR_RADIUS = 8f
         private const val OPEN_ANIMATION_MS = 250L
 
         /** Serialized so two closes in quick succession cannot write the same files at once */
         private val SAVE_EXECUTOR = java.util.concurrent.Executors.newSingleThreadExecutor { r ->
             Thread(r, "OneConfig-ConfigSave").apply { isDaemon = true }
+        }
+
+        private val savePending = java.util.concurrent.atomic.AtomicBoolean(false)
+
+        /**
+         * Writes every registered tree, once, however many closes asked for it
+         *
+         * A save queued and not yet started will write whatever the next close would have written
+         * anyway, so asking again only makes the executor serialise a second full pass over every
+         * config file. Holding the open key produced dozens of closes a second and therefore dozens
+         * of whole-config writes queued behind each other.
+         *
+         * The flag clears as the save begins rather than when it ends, so a close that lands during
+         * a write still gets one of its own.
+         */
+        private fun scheduleSave() {
+            if (!savePending.compareAndSet(false, true)) return
+            SAVE_EXECUTOR.execute {
+                savePending.set(false)
+                try {
+                    ConfigManager.active().saveAll()
+                } catch (t: Throwable) {
+                    LOGGER.error("Failed to save configs on OneConfig UI close", t)
+                }
+            }
         }
 
         /** [restored] marks a route that puts the user back where they were rather than opening a fixed page */
@@ -78,10 +127,50 @@ class OneConfigUIScreen @JvmOverloads constructor(
             else -> OpeningRoute(ModsGraph)
         }
 
+        /**
+         * Composes, lays out and draws the shared screen before anything opens it
+         *
+         * Queued at client construction and run on the first Skia frame, which lands on the title
+         * screen: the cost of the first open is paid where nobody is waiting for a frame.
+         */
+        @JvmStatic
+        fun prewarmShared(): Boolean = shared().runPrewarm()
+
+        // one at a time: a warm-up frame is not cheap and nothing waits on it finishing, and two
+        // per real frame was measured at 919 ms over 11 frames
+        private const val PREWARM_FRAME_BUDGET = 1
+
+        private const val PREWARM_OPEN_FRAME = 1
+
+        // focusing the search field lays out a paragraph, which loads the whole Skia text stack.
+        // measured at 40 ms on the frame the interface opened, whenever instant search is on
+        private const val PREWARM_FOCUS_FRAME = 2
+
+        // an icon is only rasterised when its card is first drawn, so the grid is dragged through
+        // its whole extent here to make the first real scroll free
+        private val PREWARM_SCROLL_FRAMES = 5..17
+        private const val PREWARM_RESTORE_FRAME = 18
+
+        // every page the sidebar reaches, two frames each: one to navigate, one to lay out
+        private val PREWARM_ROUTES = listOf(PreferencesGraph, ThemesGraph, KeybindsGraph, ModsGraph)
+        private const val PREWARM_FRAMES_PER_PAGE = 2
+        private val PREWARM_PAGE_FRAMES = PREWARM_RESTORE_FRAME + 1..
+            PREWARM_RESTORE_FRAME + PREWARM_ROUTES.size * PREWARM_FRAMES_PER_PAGE
+
+        /** the tour is not history the player took, so it is not left in the back stack */
+        private val PREWARM_FORGET_FRAME = PREWARM_PAGE_FRAMES.last + 1
+        private val PREWARM_CLOSE_FRAME = PREWARM_FORGET_FRAME + 1
+
+        // the schedule above decides this, so adding a route cannot leave the tail behind
+        private val PREWARM_FRAMES = PREWARM_CLOSE_FRAME + 1
+
+        /** The key the mod grid remembers its scroll position under */
+        private const val MOD_GRID_KEY = "mods"
+
         @JvmStatic
         fun openLastSession() {
             if (resolveOpeningBehaviorRoute().route === HudEditorRoute) HudManager.openEditor()
-            else Platform.screen().display(OneConfigUIScreen())
+            else Platform.screen().display(open())
         }
     }
 
@@ -91,7 +180,7 @@ class OneConfigUIScreen @JvmOverloads constructor(
     @Volatile private var openedAt = 0L
 
     private fun beginClose() {
-        if (closeRequested) return
+        if (prewarming || closeRequested) return
         closeRequested = true
         closeRequestedAt = System.currentTimeMillis()
         closeAnimationMs = guiCloseAnimationMillis()
@@ -113,14 +202,85 @@ class OneConfigUIScreen @JvmOverloads constructor(
         return true
     }
 
+    // snapshot state rather than plain fields: a composition that outlives an open has to notice
+    // these change, and recompose only the part that reads them rather than everything
+
     /** The page this screen is showing which survives the scene being disposed and rebuilt */
-    private var route: Any? = null
+    private var route: Any? by mutableStateOf(null)
 
     /** True once this screen has been displaced by another and is being shown again */
-    private var resuming = false
+    private var resuming by mutableStateOf(false)
 
     /** True when [route] is a page being put back rather than a page being opened */
-    private var restoring = false
+    private var restoring by mutableStateOf(false)
+
+    /** Set while [prewarmShared] drives the composition, so warming up cannot close or make a sound */
+    private var prewarming = false
+
+    /** Set the first time the screen is really shown, after which no warm-up may touch its scene */
+    @Volatile private var everOpened = false
+
+    private fun runPrewarm(): Boolean {
+        // a warm-up runs the clock forward and toggles visibility, which is only safe on a tree
+        // nobody has used: once shown, it carries state a warm-up has no business moving
+        if (everOpened || Platform.screen().current<Any?>() === this) return true
+        prewarming = true
+        return try {
+            ConfigRegistry.loadFrom(ConfigManager.active(), ConfigSource.OC)
+            // every card the UI can show, and both the grid and the editor's library scale with
+            // the pack, so both were resolving icons inline on the frame that first drew them
+            warmIconCache(ConfigRegistry.modCardConfigs.mapNotNull { it.icon })
+            var restoreTo = 0
+            prewarm(PREWARM_FRAMES, PREWARM_FRAME_BUDGET) { frame ->
+                // the interface raises its own visibility from a once-per-composition effect, so
+                // later passes ask; lowering it again leaves exactly what a close leaves behind
+                when (frame) {
+                    PREWARM_OPEN_FRAME -> requestOpenCallback?.invoke()
+                    PREWARM_FOCUS_FRAME -> ShellState.focusSearchField = true
+                    PREWARM_CLOSE_FRAME -> {
+                        // the warm-up focused the field; a real open decides that for itself
+                        ShellState.focusSearchField = false
+                        ShellState.searchFieldFocused = false
+                        ShellState.searchQuery = ""
+                        requestCloseCallback?.invoke()
+                    }
+                    PREWARM_RESTORE_FRAME -> scrollModGrid(restoreTo)
+                    in PREWARM_PAGE_FRAMES -> {
+                        // a page nobody has visited has never been composed, so the first visit pays
+                        // for all of it on the frame it lands: 171 ms for preferences, 37 to 55 for the rest
+                        val step = frame - PREWARM_PAGE_FRAMES.first
+                        if (step % PREWARM_FRAMES_PER_PAGE == 0) {
+                            warmRoute(PREWARM_ROUTES[step / PREWARM_FRAMES_PER_PAGE])
+                        }
+                    }
+                    PREWARM_FORGET_FRAME -> LocalNavController.wrapper.reset()
+                    in PREWARM_SCROLL_FRAMES -> {
+                        val grid = ShellState.gridStates[MOD_GRID_KEY] ?: return@prewarm
+                        if (frame == PREWARM_SCROLL_FRAMES.first) restoreTo = grid.firstVisibleItemIndex
+                        val last = (grid.layoutInfo.totalItemsCount - 1).coerceAtLeast(0)
+                        val step = frame - PREWARM_SCROLL_FRAMES.first
+                        val span = PREWARM_SCROLL_FRAMES.last - PREWARM_SCROLL_FRAMES.first
+                        scrollModGrid(last * step / span)
+                    }
+                }
+            }
+        } catch (t: Throwable) {
+            LOGGER.warn("OneConfig UI warm-up failed; the first open will build the UI instead", t)
+            false
+        } finally {
+            prewarming = false
+        }
+    }
+
+    /** The grid is only there once the mod page has composed, and only it knows how far it can go */
+    private fun scrollModGrid(index: Int) {
+        runCatching { ShellState.gridStates[MOD_GRID_KEY]?.requestScrollToItem(index) }
+    }
+
+    /** The nav host only exists once the shell has composed, so a warm-up asks rather than assumes */
+    private fun warmRoute(route: Any) {
+        runCatching { if (LocalNavController.isReady) LocalNavController.wrapper.navigate(route) }
+    }
 
     private fun markClosed() {
         ShellState.lastClosedAt = System.currentTimeMillis()
@@ -131,18 +291,20 @@ class OneConfigUIScreen @JvmOverloads constructor(
         ConfigRegistry.loadFrom(ConfigManager.active(), ConfigSource.OC)
         initialTree?.let { ConfigRegistry.registerTree(it, ConfigSource.OC) }
 
-        if (route == null) {
-            when {
-                initialRoute != null -> route = initialRoute
-                initialTreeId != null -> route = ModConfigRoute(initialTreeId, initialCategory)
-                else -> {
-                    val opening = resolveOpeningBehaviorRoute()
-                    route = opening.route.takeIf { it !== HudEditorRoute } ?: ModsGraph
-                    restoring = opening.restored && route === opening.route
-                }
+        // resolved on every open so opening behaviour still applies to a reused screen. writing the
+        // same value back is free: snapshot state only records a write that changes something
+        val (target, targetRestoring) = when {
+            initialRoute != null -> initialRoute to restoring
+            initialTreeId != null -> ModConfigRoute(initialTreeId, initialCategory) to restoring
+            else -> {
+                val opening = resolveOpeningBehaviorRoute()
+                val resolved = opening.route.takeIf { it !== HudEditorRoute } ?: ModsGraph
+                resolved to (opening.restored && resolved === opening.route)
             }
-            ShellState.lastRoute = route
         }
+        route = target
+        restoring = targetRestoring
+        ShellState.lastRoute = target
 
         try {
             ShellState.playerName = net.minecraft.client.Minecraft.getInstance().user.name
@@ -189,10 +351,21 @@ class OneConfigUIScreen @JvmOverloads constructor(
         HudManager.overrideShowInScreens = true
         HudManager.isConfigUiOpen = true
 
+        // a reused screen still carries the close it was dismissed by, and left set the opening
+        // frame computes a finished closing animation and renders fully faded out
+        closeRequested = false
+        closeRequestedAt = 0L
+        closeAnimationMs = 0L
+
+        everOpened = true
         openedAt = System.currentTimeMillis()
         UiSounds.play(UiSoundEvent.OPEN)
         UiSounds.acquireAmbience()
         super.init()
+
+        // the interface raises its visibility from a LaunchedEffect(Unit), so a composition that
+        // outlives a close comes back invisible. ask it to open, exactly as cancelClose does
+        requestOpenCallback?.invoke()
     }
 
     /**
@@ -215,16 +388,14 @@ class OneConfigUIScreen @JvmOverloads constructor(
         SkiaCtx.suppressInGameHudRender = false
         HudManager.overrideShowInScreens = false
         HudManager.isConfigUiOpen = false
-        org.polyfrost.oneconfig.internal.ui.SkiaOffscreenTarget.destroyAll()
+        // the shell is no longer laid out but its last bounds would still answer hit tests, and the
+        // HUD editor asks them to decide what a click is over
+        ShellState.shellBounds = null
+        // the offscreen targets stay alive across opens: resolveTarget rebuilds them when the
+        // viewport changes, so releasing them here only made the next open pay for fresh ones
         UiSounds.releaseAmbience()
         // writing every registered tree hitches and Minecraft only re-grabs the cursor once this returns
-        SAVE_EXECUTOR.execute {
-            try {
-                ConfigManager.active().saveAll()
-            } catch (t: Throwable) {
-                LOGGER.error("Failed to save configs on OneConfig UI close", t)
-            }
-        }
+        scheduleSave()
         super.removed()
     }
 

--- a/minecraft/src/main/kotlin/org/polyfrost/oneconfig/internal/ui/hud/DebugOverlayOffscreen.kt
+++ b/minecraft/src/main/kotlin/org/polyfrost/oneconfig/internal/ui/hud/DebugOverlayOffscreen.kt
@@ -49,22 +49,8 @@ object DebugOverlayOffscreen {
             Platform.screen().current<Any?>() is ComposeScreen &&
             client.debugOverlay.showDebugScreen()
 
-    /**
-     * Called from the debug overlay mixin to hide the vanilla under-UI blurred copy
-     *
-     * Gated on [hasContent] so vanilla is only cancelled once there is a capture to put in its
-     * place. Without it the frame a screen opens on cancels vanilla while the offscreen target is
-     * still being resolved, and the overlay disappears for that frame
-     */
     fun shouldSuppressVanilla(): Boolean = !capturing && hasContent && active()
 
-    /**
-     * Records the overlay into the offscreen target
-     *
-     * [hasContent] is deliberately not cleared on the way in: the mixin read it earlier in the
-     * frame, so a failed record would blit nothing over a vanilla overlay already cancelled. Keeping
-     * the last capture makes the worst case a slightly stale frame rather than an empty one.
-     */
     fun render() {
         if (!active()) return
         val w = Platform.screen().viewportWidth()

--- a/minecraft/src/main/kotlin/org/polyfrost/oneconfig/internal/ui/hud/DebugOverlayOffscreen.kt
+++ b/minecraft/src/main/kotlin/org/polyfrost/oneconfig/internal/ui/hud/DebugOverlayOffscreen.kt
@@ -49,11 +49,23 @@ object DebugOverlayOffscreen {
             Platform.screen().current<Any?>() is ComposeScreen &&
             client.debugOverlay.showDebugScreen()
 
-    /** Called from the debug overlay mixin to hide the vanilla under-UI blurred copy */
-    fun shouldSuppressVanilla(): Boolean = !capturing && active()
+    /**
+     * Called from the debug overlay mixin to hide the vanilla under-UI blurred copy
+     *
+     * Gated on [hasContent] so vanilla is only cancelled once there is a capture to put in its
+     * place. Without it the frame a screen opens on cancels vanilla while the offscreen target is
+     * still being resolved, and the overlay disappears for that frame
+     */
+    fun shouldSuppressVanilla(): Boolean = !capturing && hasContent && active()
 
+    /**
+     * Records the overlay into the offscreen target
+     *
+     * [hasContent] is deliberately not cleared on the way in: the mixin read it earlier in the
+     * frame, so a failed record would blit nothing over a vanilla overlay already cancelled. Keeping
+     * the last capture makes the worst case a slightly stale frame rather than an empty one.
+     */
     fun render() {
-        hasContent = false
         if (!active()) return
         val w = Platform.screen().viewportWidth()
         val h = Platform.screen().viewportHeight()
@@ -72,6 +84,7 @@ object DebugOverlayOffscreen {
             hasContent = true
         } catch (t: Throwable) {
             LOG.warn("Debug overlay offscreen render failed; disabling", t)
+            hasContent = false
             failed = true
             capturing = false
             GuiTargetRedirect.target = null

--- a/minecraft/src/main/kotlin/org/polyfrost/oneconfig/internal/ui/hud/DebugOverlayOffscreen.kt
+++ b/minecraft/src/main/kotlin/org/polyfrost/oneconfig/internal/ui/hud/DebugOverlayOffscreen.kt
@@ -160,7 +160,7 @@ object DebugOverlayOffscreen {
     *///? }
 
     private fun drawInto(canvas: org.jetbrains.skia.Canvas) {
-        if (!hasContent) return
+        if (!hasContent || !active()) return
         val s = offscreen.surface ?: return
         try {
             s.notifyContentWillChange(org.jetbrains.skia.ContentChangeMode.RETAIN)

--- a/minecraft/src/main/kotlin/org/polyfrost/oneconfig/internal/ui/hud/LegacyHudOffscreen.kt
+++ b/minecraft/src/main/kotlin/org/polyfrost/oneconfig/internal/ui/hud/LegacyHudOffscreen.kt
@@ -35,19 +35,27 @@ object LegacyHudOffscreen {
         LegacyHudOverlayBridge.painter = { c -> drawInto(c) }
     }
 
+    /**
+     * Records the legacy HUDs into the offscreen target so Skia can composite them above the UI
+     *
+     * Returns whether the HUD has been dealt with. False hands it back to the caller's live
+     * renderer, so every path that fails to record has to report false, since returning true without
+     * setting [hasContent] suppresses the live renderer and leaves the HUD missing for that frame
+     */
     fun render(): Boolean {
         hasContent = false
         if (failed) return false
         if (java.lang.Boolean.getBoolean("oneconfig.disable.legacyHudOffscreen")) return false
+        // nothing to record, so there is nothing for the live renderer to draw either
         if (HudManager.activeInstances.none { it is LegacyHud } && !CompatOverlayRenderer.hasHooks()) return true
-        if (!SkiaCtx.isReady) return true
+        if (!SkiaCtx.isReady) return false
         val w = Platform.screen().viewportWidth()
         val h = Platform.screen().viewportHeight()
-        if (w <= 0 || h <= 0) return true
+        if (w <= 0 || h <= 0) return false
 
         try {
-            if (!offscreen.resolveTarget(w, h)) return true
-            val rt = offscreen.target ?: return true
+            if (!offscreen.resolveTarget(w, h)) return false
+            val rt = offscreen.target ?: return false
             //? if >= 1.21.8 {
             renderRecorded(rt)
             //?} elif >= 1.21.5 {

--- a/minecraft/src/main/kotlin/org/polyfrost/oneconfig/internal/ui/hud/LegacyHudOffscreen.kt
+++ b/minecraft/src/main/kotlin/org/polyfrost/oneconfig/internal/ui/hud/LegacyHudOffscreen.kt
@@ -35,18 +35,10 @@ object LegacyHudOffscreen {
         LegacyHudOverlayBridge.painter = { c -> drawInto(c) }
     }
 
-    /**
-     * Records the legacy HUDs into the offscreen target so Skia can composite them above the UI
-     *
-     * Returns whether the HUD has been dealt with. False hands it back to the caller's live
-     * renderer, so every path that fails to record has to report false, since returning true without
-     * setting [hasContent] suppresses the live renderer and leaves the HUD missing for that frame
-     */
     fun render(): Boolean {
         hasContent = false
         if (failed) return false
         if (java.lang.Boolean.getBoolean("oneconfig.disable.legacyHudOffscreen")) return false
-        // nothing to record, so there is nothing for the live renderer to draw either
         if (HudManager.activeInstances.none { it is LegacyHud } && !CompatOverlayRenderer.hasHooks()) return true
         if (!SkiaCtx.isReady) return false
         val w = Platform.screen().viewportWidth()

--- a/minecraft/src/main/kotlin/org/polyfrost/oneconfig/utils/v1/dsl/screens.kt
+++ b/minecraft/src/main/kotlin/org/polyfrost/oneconfig/utils/v1/dsl/screens.kt
@@ -45,7 +45,7 @@ fun Tree.createScreen(): Screen {
         ConfigRegistry.registerTree(this, ConfigSource.OC)
         return OneConfigUIScreen(treeId, null, this)
     }
-    return OneConfigUIScreen()
+    return OneConfigUIScreen.open()
 }
 
 fun Tree.createScreen(initialCategory: String): Screen {
@@ -54,7 +54,7 @@ fun Tree.createScreen(initialCategory: String): Screen {
         ConfigRegistry.registerTree(this, ConfigSource.OC)
         return OneConfigUIScreen(treeId, initialCategory, this)
     }
-    return OneConfigUIScreen()
+    return OneConfigUIScreen.open()
 }
 
 fun Tree.openUI() = Platform.screen().display(createScreen())
@@ -66,7 +66,7 @@ fun Config.createScreen(): Screen {
         preload()
         this.tree
     }
-    return tree?.createScreen() ?: OneConfigUIScreen()
+    return tree?.createScreen() ?: OneConfigUIScreen.open()
 }
 
 fun Config.createScreen(initialCategory: String): Screen {
@@ -74,7 +74,7 @@ fun Config.createScreen(initialCategory: String): Screen {
         preload()
         this.tree
     }
-    return tree?.createScreen(initialCategory) ?: OneConfigUIScreen()
+    return tree?.createScreen(initialCategory) ?: OneConfigUIScreen.open()
 }
 
 fun Config.openUI() = Platform.screen().display(createScreen())

--- a/modules/config-impl/src/main/java/org/polyfrost/oneconfig/api/config/v1/collect/impl/ReflectiveCollector.java
+++ b/modules/config-impl/src/main/java/org/polyfrost/oneconfig/api/config/v1/collect/impl/ReflectiveCollector.java
@@ -60,12 +60,13 @@ public abstract class ReflectiveCollector implements PropertyCollector {
 
 
     public void handle(@NotNull Tree tree, @NotNull Object src, int depth) {
-        if (src == null) {
-            LOGGER.error("Failed to collect properties for {} from object {} as the object was null", tree.getID(), src);
+        // tree first: the object's message names the tree, so it cannot run while the tree is null
+        if (tree == null) {
+            LOGGER.error("Failed to collect properties from object {} as the tree was null", src);
             return;
         }
-        if (tree == null) {
-            LOGGER.error("Failed to collect properties for {} from object {} as the tree was null", tree.getID(), src);
+        if (src == null) {
+            LOGGER.error("Failed to collect properties for {} as the object was null", tree.getID());
             return;
         }
         Class<?> cls = src.getClass();
@@ -75,8 +76,10 @@ public abstract class ReflectiveCollector implements PropertyCollector {
         for (Method m : cls.getDeclaredMethods()) {
             handleMethod(m, src, tree);
         }
+        // stops at Object, which declares no config properties: walking it reflected over its
+        // eleven methods per config per nesting level. ObjectSerializer.getAllFields stops there too
         Class<?> superClass = cls.getSuperclass();
-        while (superClass != null) {
+        while (superClass != null && superClass != Object.class) {
             for (Field f : superClass.getDeclaredFields()) {
                 handleField(f, src, tree);
             }

--- a/modules/config-impl/src/main/java/org/polyfrost/oneconfig/api/config/v1/collect/impl/ReflectiveCollector.java
+++ b/modules/config-impl/src/main/java/org/polyfrost/oneconfig/api/config/v1/collect/impl/ReflectiveCollector.java
@@ -60,7 +60,6 @@ public abstract class ReflectiveCollector implements PropertyCollector {
 
 
     public void handle(@NotNull Tree tree, @NotNull Object src, int depth) {
-        // tree first: the object's message names the tree, so it cannot run while the tree is null
         if (tree == null) {
             LOGGER.error("Failed to collect properties from object {} as the tree was null", src);
             return;
@@ -76,8 +75,6 @@ public abstract class ReflectiveCollector implements PropertyCollector {
         for (Method m : cls.getDeclaredMethods()) {
             handleMethod(m, src, tree);
         }
-        // stops at Object, which declares no config properties: walking it reflected over its
-        // eleven methods per config per nesting level. ObjectSerializer.getAllFields stops there too
         Class<?> superClass = cls.getSuperclass();
         while (superClass != null && superClass != Object.class) {
             for (Field f : superClass.getDeclaredFields()) {

--- a/modules/config/src/main/java/org/polyfrost/oneconfig/api/config/v1/Property.java
+++ b/modules/config/src/main/java/org/polyfrost/oneconfig/api/config/v1/Property.java
@@ -442,7 +442,9 @@ public abstract class Property<T> extends Node implements Serializable {
         public void set0(@Nullable T value) {
             try {
                 T it = get();
-                if (it != null && complex) {
+                // overwrite() says "cannot write through this" by throwing, and set0 runs once a
+                // frame for the length of a drag, so ask the same question rather than catch it
+                if (it != null && complex && !ObjectSerializer.isImmutable(it.getClass())) {
                     try {
                         ObjectSerializer.overwrite(it, value);
                     } catch (Throwable ignored) {

--- a/modules/config/src/main/java/org/polyfrost/oneconfig/api/config/v1/Property.java
+++ b/modules/config/src/main/java/org/polyfrost/oneconfig/api/config/v1/Property.java
@@ -442,8 +442,6 @@ public abstract class Property<T> extends Node implements Serializable {
         public void set0(@Nullable T value) {
             try {
                 T it = get();
-                // overwrite() says "cannot write through this" by throwing, and set0 runs once a
-                // frame for the length of a drag, so ask the same question rather than catch it
                 if (it != null && complex && !ObjectSerializer.isImmutable(it.getClass())) {
                     try {
                         ObjectSerializer.overwrite(it, value);

--- a/modules/events/src/main/java/org/polyfrost/oneconfig/api/event/v1/EventManager.java
+++ b/modules/events/src/main/java/org/polyfrost/oneconfig/api/event/v1/EventManager.java
@@ -45,11 +45,11 @@ import java.util.ArrayDeque;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Deque;
-import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.WeakHashMap;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.function.Consumer;
 import java.util.stream.Collectors;
@@ -64,8 +64,10 @@ public final class EventManager {
     public static final EventManager INSTANCE = new EventManager();
     private static final Logger LOGGER = LogManager.getLogger("OneConfig/Events");
     private final Deque<EventCollector> collectors = new ArrayDeque<>(2);
-    private final Map<Object, Iterable<EventHandler<?>>> cache = new WeakHashMap<>(5);
-    private final Map<Class<? extends Event>, List<EventHandler<?>>> handlers = new HashMap<>(8);
+    private final Map<Object, Iterable<EventHandler<?>>> cache = Collections.synchronizedMap(new WeakHashMap<>(5));
+    // concurrent because post reads it from whichever thread fires the event while mods register
+    // from the main thread, and packet events come off the netty loop
+    private final Map<Class<? extends Event>, List<EventHandler<?>>> handlers = new ConcurrentHashMap<>(8);
 
     private EventManager() {
         registerCollector(new AnnotationEventMapper());
@@ -231,6 +233,17 @@ public final class EventManager {
 
     public void registerCollector(EventCollector collector) {
         collectors.addFirst(collector);
+    }
+
+    /**
+     * Whether anything is listening for {@code cls}, so a hot call site can skip building an event
+     * nobody would receive. Entity render and packet events fire thousands of times a second.
+     *
+     * @param cls the concrete event type, as passed to {@link #post}
+     */
+    public boolean hasListeners(Class<? extends Event> cls) {
+        List<EventHandler<?>> handles = handlers.get(cls);
+        return handles != null && !handles.isEmpty();
     }
 
     /**

--- a/modules/events/src/main/java/org/polyfrost/oneconfig/api/event/v1/EventManager.java
+++ b/modules/events/src/main/java/org/polyfrost/oneconfig/api/event/v1/EventManager.java
@@ -65,8 +65,6 @@ public final class EventManager {
     private static final Logger LOGGER = LogManager.getLogger("OneConfig/Events");
     private final Deque<EventCollector> collectors = new ArrayDeque<>(2);
     private final Map<Object, Iterable<EventHandler<?>>> cache = Collections.synchronizedMap(new WeakHashMap<>(5));
-    // concurrent because post reads it from whichever thread fires the event while mods register
-    // from the main thread, and packet events come off the netty loop
     private final Map<Class<? extends Event>, List<EventHandler<?>>> handlers = new ConcurrentHashMap<>(8);
 
     private EventManager() {
@@ -235,12 +233,6 @@ public final class EventManager {
         collectors.addFirst(collector);
     }
 
-    /**
-     * Whether anything is listening for {@code cls}, so a hot call site can skip building an event
-     * nobody would receive. Entity render and packet events fire thousands of times a second.
-     *
-     * @param cls the concrete event type, as passed to {@link #post}
-     */
     public boolean hasListeners(Class<? extends Event> cls) {
         List<EventHandler<?>> handles = handlers.get(cls);
         return handles != null && !handles.isEmpty();

--- a/modules/hud/src/main/kotlin/org/polyfrost/oneconfig/api/hud/v1/Hud.kt
+++ b/modules/hud/src/main/kotlin/org/polyfrost/oneconfig/api/hud/v1/Hud.kt
@@ -967,6 +967,16 @@ abstract class Hud(id: String, title: String, val category: Category) : Cloneabl
     @JvmField
     var lastLayoutFrame: Long = -1L
 
+    /**
+     * [System.nanoTime] when [update] last ran, or [Long.MIN_VALUE] if it never has
+     *
+     * nanoTime has an arbitrary origin and may be negative, so 0 and -1 are both legal readings
+     * and cannot stand in for "never"
+     */
+    @ApiStatus.Internal
+    @JvmField
+    var lastUpdate: Long = Long.MIN_VALUE
+
     override fun addToInitQueue() {}
 
     val isReal get() = tree != null

--- a/modules/hud/src/main/kotlin/org/polyfrost/oneconfig/api/hud/v1/Hud.kt
+++ b/modules/hud/src/main/kotlin/org/polyfrost/oneconfig/api/hud/v1/Hud.kt
@@ -967,12 +967,6 @@ abstract class Hud(id: String, title: String, val category: Category) : Cloneabl
     @JvmField
     var lastLayoutFrame: Long = -1L
 
-    /**
-     * [System.nanoTime] when [update] last ran, or [Long.MIN_VALUE] if it never has
-     *
-     * nanoTime has an arbitrary origin and may be negative, so 0 and -1 are both legal readings
-     * and cannot stand in for "never"
-     */
     @ApiStatus.Internal
     @JvmField
     var lastUpdate: Long = Long.MIN_VALUE

--- a/modules/hud/src/main/kotlin/org/polyfrost/oneconfig/api/hud/v1/HudManager.kt
+++ b/modules/hud/src/main/kotlin/org/polyfrost/oneconfig/api/hud/v1/HudManager.kt
@@ -149,8 +149,6 @@ object HudManager {
     @ApiStatus.Internal
     @Volatile @JvmField var pendingAdd: Hud? = null
 
-    private val lastUpdates = HashMap<Hud, Long>()
-
     private var wasEditing = false
 
     private val redrawCacheDisabled = java.lang.Boolean.getBoolean("oneconfig.hud.nocache")
@@ -178,6 +176,9 @@ object HudManager {
 
     /** [frameOrder] plus the hidden HUDs which still contribute their background to a fused shape */
     private val layoutOrder = ArrayList<Hud>()
+
+    /** Everything [prepare] lays out, reused rather than refiltered into a new list each frame */
+    private val prepareOrder = ArrayList<Hud>()
 
     private var frameGroups: List<HudBackgroundMerge.Group> = emptyList()
     private var lastMergeKey: Int? = null
@@ -349,6 +350,15 @@ object HudManager {
         return out
     }
 
+    /**
+     * Whether any instance of [hudClass] is active
+     *
+     * Short-circuits on the first match and builds no list, unlike [getHudsOfType]. Callers that
+     * only need to know whether the type is present should prefer this, since the library asks once
+     * per provider on every recomposition
+     */
+    fun hasHudOfType(hudClass: Class<out Hud>): Boolean = activeInstances.any { it::class.java == hudClass }
+
     fun getProvider(hudClass: Class<out Hud>): Hud? = hudProviders[hudClass]
 
     /** The live HUD whose config tree has this [id] used to resolve [Hud.anchorTargetId] */
@@ -398,7 +408,7 @@ object HudManager {
         // profiles active at the same time.
         cleanup { hud._runtime?.dispose() }
         hud._runtime = null
-        lastUpdates.remove(hud)
+        hud.lastUpdate = Long.MIN_VALUE
         // anything hanging off this HUD goes back to screen positioning and stays where it is
         // because the relative position kept alongside the anchor is already up to date
         treeId?.let { gone ->
@@ -468,7 +478,7 @@ object HudManager {
         // one immediate update on the edge instead of waiting out its remaining interval
         if (wasEditing != isEditing) {
             wasEditing = isEditing
-            lastUpdates.clear()
+            for (hud in activeInstances) hud.lastUpdate = Long.MIN_VALUE
         }
         for (hud in huds) {
             try {
@@ -478,6 +488,9 @@ object HudManager {
             }
         }
         if (PolyComposeHost.frameWithReport()) invalidate()
+        // previews are only ever on screen behind a OneConfig UI, so that is when their clock runs.
+        // notify=false because the line above already applied this frame's snapshot writes
+        if (isConfigUiOpen || isEditorOpen) PolyComposeHost.previews.frame(notify = false)
     }
 
     private fun layout(hud: Hud, screenWidth: Float, screenHeight: Float, scale: Float): RootNode {
@@ -504,9 +517,9 @@ object HudManager {
             return
         }
         val now = System.nanoTime()
-        val last = lastUpdates[hud]
-        if (last != null && now - last < frequency) return
-        lastUpdates[hud] = now
+        val last = hud.lastUpdate
+        if (last != Long.MIN_VALUE && now - last < frequency) return
+        hud.lastUpdate = now
         hud.update()
     }
 
@@ -782,7 +795,9 @@ object HudManager {
         val scale = Platform.compatibility().options().guiScale
         Snapshot.sendApplyNotifications()
         frameId++
-        val huds = activeInstances.filterNot { it is LegacyHudMarker }
+        val huds = prepareOrder
+        huds.clear()
+        for (hud in activeInstances) if (hud !is LegacyHudMarker) huds.add(hud)
         updateAndAdvance(huds)
         for (hud in huds) {
             try {

--- a/modules/hud/src/main/kotlin/org/polyfrost/oneconfig/api/hud/v1/HudManager.kt
+++ b/modules/hud/src/main/kotlin/org/polyfrost/oneconfig/api/hud/v1/HudManager.kt
@@ -153,11 +153,9 @@ object HudManager {
 
     private val showingPreviews get() = isConfigUiOpen || isEditorOpen
 
-    /** bumped when a preview's content changed, so previews redraw on that frame and nothing else */
     @ApiStatus.Internal
     val previewRevision = mutableIntStateOf(0)
 
-    /** bumped by a real open, so a retained editor still picks up what was left pending for it */
     @ApiStatus.Internal
     val editorOpenRevision = mutableIntStateOf(0)
 
@@ -187,7 +185,6 @@ object HudManager {
     /** [frameOrder] plus the hidden HUDs which still contribute their background to a fused shape */
     private val layoutOrder = ArrayList<Hud>()
 
-    /** Everything [prepare] lays out, reused rather than refiltered into a new list each frame */
     private val prepareOrder = ArrayList<Hud>()
 
     private var frameGroups: List<HudBackgroundMerge.Group> = emptyList()
@@ -360,13 +357,6 @@ object HudManager {
         return out
     }
 
-    /**
-     * Whether any instance of [hudClass] is active
-     *
-     * Short-circuits on the first match and builds no list, unlike [getHudsOfType]. Callers that
-     * only need to know whether the type is present should prefer this, since the library asks once
-     * per provider on every recomposition
-     */
     fun hasHudOfType(hudClass: Class<out Hud>): Boolean = activeInstances.any { it::class.java == hudClass }
 
     fun getProvider(hudClass: Class<out Hud>): Hud? = hudProviders[hudClass]
@@ -497,16 +487,10 @@ object HudManager {
                 LOGGER.error("Failed to update HUD ${hud.title}", e)
             }
         }
-        // a preview mirrors a provider, and providers are not active instances, so nothing else
-        // advances what one shows. before the notify below, so this frame composes against it
         if (showingPreviews) for (hud in hudProviders.values) updateIfDue(hud)
         if (PolyComposeHost.frameWithReport()) invalidate()
-        // previews are only ever on screen behind a OneConfig UI, so that is when their clock runs.
-        // notify=false because the line above already applied this frame's snapshot writes
         if (showingPreviews) {
             PolyComposeHost.previews.frame(notify = false)
-            // a preview draws without observing what it reads, so this is the only thing that
-            // tells it to redraw, and only on a frame that actually changed something
             if (PolyComposeHost.previews.appliedChange) previewRevision.intValue++
         }
     }

--- a/modules/hud/src/main/kotlin/org/polyfrost/oneconfig/api/hud/v1/HudManager.kt
+++ b/modules/hud/src/main/kotlin/org/polyfrost/oneconfig/api/hud/v1/HudManager.kt
@@ -151,6 +151,16 @@ object HudManager {
 
     private var wasEditing = false
 
+    private val showingPreviews get() = isConfigUiOpen || isEditorOpen
+
+    /** bumped when a preview's content changed, so previews redraw on that frame and nothing else */
+    @ApiStatus.Internal
+    val previewRevision = mutableIntStateOf(0)
+
+    /** bumped by a real open, so a retained editor still picks up what was left pending for it */
+    @ApiStatus.Internal
+    val editorOpenRevision = mutableIntStateOf(0)
+
     private val redrawCacheDisabled = java.lang.Boolean.getBoolean("oneconfig.hud.nocache")
 
     @Volatile private var contentDirty = true
@@ -487,10 +497,18 @@ object HudManager {
                 LOGGER.error("Failed to update HUD ${hud.title}", e)
             }
         }
+        // a preview mirrors a provider, and providers are not active instances, so nothing else
+        // advances what one shows. before the notify below, so this frame composes against it
+        if (showingPreviews) for (hud in hudProviders.values) updateIfDue(hud)
         if (PolyComposeHost.frameWithReport()) invalidate()
         // previews are only ever on screen behind a OneConfig UI, so that is when their clock runs.
         // notify=false because the line above already applied this frame's snapshot writes
-        if (isConfigUiOpen || isEditorOpen) PolyComposeHost.previews.frame(notify = false)
+        if (showingPreviews) {
+            PolyComposeHost.previews.frame(notify = false)
+            // a preview draws without observing what it reads, so this is the only thing that
+            // tells it to redraw, and only on a frame that actually changed something
+            if (PolyComposeHost.previews.appliedChange) previewRevision.intValue++
+        }
     }
 
     private fun layout(hud: Hud, screenWidth: Float, screenHeight: Float, scale: Float): RootNode {

--- a/modules/internal/src/main/kotlin/org/polyfrost/oneconfig/internal/ui/OneConfigInterface.kt
+++ b/modules/internal/src/main/kotlin/org/polyfrost/oneconfig/internal/ui/OneConfigInterface.kt
@@ -63,6 +63,7 @@ fun OneConfigInterface(
     resuming: Boolean = false,
     /** Set when [initialRoute] is a page the user was already on which is put back without a transition */
     restoring: Boolean = false,
+    openRevision: Int = 0,
     onCloseRequest: () -> Unit = {},
     onCloseReady: ((requestClose: () -> Unit) -> Unit)? = null,
     onOpenReady: ((requestOpen: () -> Unit) -> Unit)? = null,
@@ -72,13 +73,8 @@ fun OneConfigInterface(
 
     LocalNavController.current = rememberNavController()
 
-    // the composition holding the nav controller now outlives a close, so only the very first one
-    // is already sitting on the start destination and every open after it has to navigate
-    var everRouted by remember { mutableStateOf(false) }
-
-    LaunchedEffect(initialRoute) {
-        val alreadyThere = initialRoute == ModsGraph && !everRouted
-        everRouted = true
+    LaunchedEffect(initialRoute, openRevision) {
+        val alreadyThere = initialRoute == LocalNavController.wrapper.currentRoute
         if (!resuming) {
             ShellState.globalSearchActive = false
             ShellState.searchQuery = ""

--- a/modules/internal/src/main/kotlin/org/polyfrost/oneconfig/internal/ui/OneConfigInterface.kt
+++ b/modules/internal/src/main/kotlin/org/polyfrost/oneconfig/internal/ui/OneConfigInterface.kt
@@ -1,22 +1,12 @@
 package org.polyfrost.oneconfig.internal.ui
 
-import androidx.compose.animation.AnimatedVisibility
-import androidx.compose.animation.EnterExitState
-import androidx.compose.animation.EnterTransition
-import androidx.compose.animation.ExitTransition
 import androidx.compose.animation.core.EaseOutCubic
-import androidx.compose.animation.core.animateFloat
 import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.animation.core.tween
-import androidx.compose.animation.fadeIn
-import androidx.compose.animation.fadeOut
-import androidx.compose.animation.scaleIn
-import androidx.compose.animation.scaleOut
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
-import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.compositionLocalOf
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.SideEffect
@@ -30,7 +20,6 @@ import androidx.compose.runtime.withFrameNanos
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.geometry.Offset
-import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.graphics.drawscope.DrawScope
 import androidx.compose.ui.layout.boundsInRoot
 import androidx.compose.ui.layout.onGloballyPositioned
@@ -43,6 +32,7 @@ import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.withTimeoutOrNull
 import org.apache.logging.log4j.LogManager
 import org.polyfrost.oneconfig.internal.OneConfigConfig
+import org.polyfrost.oneconfig.internal.ui.components.RetainedVisibility
 import org.polyfrost.oneconfig.internal.ui.hud.screens.HudDragLayer
 import org.polyfrost.oneconfig.internal.ui.navigation.graph.ModsGraph
 import org.polyfrost.oneconfig.internal.ui.shell.Lifecycle
@@ -82,7 +72,13 @@ fun OneConfigInterface(
 
     LocalNavController.current = rememberNavController()
 
+    // the composition holding the nav controller now outlives a close, so only the very first one
+    // is already sitting on the start destination and every open after it has to navigate
+    var everRouted by remember { mutableStateOf(false) }
+
     LaunchedEffect(initialRoute) {
+        val alreadyThere = initialRoute == ModsGraph && !everRouted
+        everRouted = true
         if (!resuming) {
             ShellState.globalSearchActive = false
             ShellState.searchQuery = ""
@@ -90,8 +86,8 @@ fun OneConfigInterface(
         }
 
         ShellState.openingTransitionTarget = null
-        ShellState.awaitingInitialRoute = initialRoute != ModsGraph
-        if (initialRoute != ModsGraph) {
+        ShellState.awaitingInitialRoute = !alreadyThere
+        if (!alreadyThere) {
             // an initial navigation fires a page transition gated by "Show opening page animation" unless
             // the page is only being put back which should look like it was never left
             ShellState.initialTransitionConsumed = false
@@ -174,41 +170,25 @@ fun OneConfigInterface(
                 ) {
                     Theme(pixelGrid = true) {
                         val animMs = (OneConfigConfig.animationTime * 1000f).toInt().coerceAtLeast(1)
-                        val exitMs = guiCloseAnimationMillis().toInt()
-                        val enter = if (OneConfigConfig.guiOpenAnimation)
-                            fadeIn(tween(animMs, easing = EaseOutExpo)) + scaleIn(tween(animMs, easing = EaseOutExpo), initialScale = 0.9f)
-                        else EnterTransition.None
-                        val exit = if (exitMs > 0)
-                            fadeOut(tween(exitMs, easing = EaseOutCubic)) + scaleOut(tween(exitMs, easing = EaseOutCubic), targetScale = 0.9f)
-                        else ExitTransition.None
+                        val enterMs = if (OneConfigConfig.guiOpenAnimation) animMs else 1
+                        val exitMs = guiCloseAnimationMillis().toInt().coerceAtLeast(1)
                         val dragAlpha by animateFloatAsState(
                             targetValue = if (ShellState.hudDragging) OneConfigConfig.hudDragUiOpacity.coerceIn(0f, 1f) else 1f,
                             animationSpec = tween(150),
                             label = "hudDragShellAlpha"
                         )
-                        AnimatedVisibility(
+
+                        RetainedVisibility(
                             visible = visible,
-                            enter = enter,
-                            exit = exit,
-                        ) {
-                            val contentAlpha by transition.animateFloat(
-                                transitionSpec = {
-                                    if (targetState == EnterExitState.Visible) tween(animMs, easing = EaseOutExpo)
-                                    else tween(exitMs.coerceAtLeast(1), easing = EaseOutCubic)
-                                },
-                                label = "oneconfigContentAlpha",
-                            ) { state -> if (state == EnterExitState.Visible) 1f else 0f }
-                            DisposableEffect(Unit) { onDispose { ShellState.shellBounds = null } }
-                            CompositionLocalProvider(
-                                LocalOneConfigContentAlpha provides (contentAlpha * dragAlpha),
-                            ) {
-                                Box(
-                                    modifier = Modifier
-                                        .onGloballyPositioned { ShellState.shellBounds = it.boundsInRoot() }
-                                        .then(if (dragAlpha < 1f) Modifier.graphicsLayer { alpha = dragAlpha } else Modifier)
-                                ) {
-                                    Shell(windowWidth, windowHeight, shellBackdrop)
-                                }
+                            enter = tween(enterMs, easing = EaseOutExpo),
+                            exit = tween(exitMs, easing = EaseOutCubic),
+                            alphaMultiplier = dragAlpha,
+                            modifier = Modifier.onGloballyPositioned {
+                                ShellState.shellBounds = it.boundsInRoot()
+                            },
+                        ) { alpha ->
+                            CompositionLocalProvider(LocalOneConfigContentAlpha provides alpha) {
+                                Shell(windowWidth, windowHeight, shellBackdrop)
                             }
                         }
                     }

--- a/modules/internal/src/main/kotlin/org/polyfrost/oneconfig/internal/ui/api/ConfigRegistry.kt
+++ b/modules/internal/src/main/kotlin/org/polyfrost/oneconfig/internal/ui/api/ConfigRegistry.kt
@@ -129,7 +129,6 @@ object ConfigRegistry {
         onOpen: (() -> Unit)? = null,
         bumpRevision: Boolean = true
     ): Boolean {
-        // the bulk reload every open does passes false; an explicit registration is a real change
         MinecraftKeybindRegistrar.scan(tree, force = bumpRevision)
         if (tree.id == null || tree.title == null) return false
         if (tree.getMetadata<Any?>("hidden") != null) return false

--- a/modules/internal/src/main/kotlin/org/polyfrost/oneconfig/internal/ui/api/ConfigRegistry.kt
+++ b/modules/internal/src/main/kotlin/org/polyfrost/oneconfig/internal/ui/api/ConfigRegistry.kt
@@ -58,11 +58,8 @@ object ConfigRegistry {
 
     val configs: SnapshotStateList<ConfigData> = mutableStateListOf()
 
-    val configList: List<ConfigData>
-        get() = configs.toList()
-
     val modCardConfigs: List<ConfigData>
-        get() = configList.filter(::shouldShowModCard) + hudModCardConfigs()
+        get() = configs.filter(::shouldShowModCard) + hudModCardConfigs()
 
     var revision by mutableIntStateOf(0)
         private set
@@ -116,7 +113,6 @@ object ConfigRegistry {
         var changed = false
         manager.trees().forEach { tree ->
             tree.id?.let(seenIds::add)
-            MinecraftKeybindRegistrar.scan(tree)
             if (registerTree(tree, source, bumpRevision = false)) changed = true
         }
         if (configs.removeAll { it.source == source && it is TreeConfigData && it.id !in seenIds }) changed = true
@@ -133,7 +129,8 @@ object ConfigRegistry {
         onOpen: (() -> Unit)? = null,
         bumpRevision: Boolean = true
     ): Boolean {
-        MinecraftKeybindRegistrar.scan(tree)
+        // the bulk reload every open does passes false; an explicit registration is a real change
+        MinecraftKeybindRegistrar.scan(tree, force = bumpRevision)
         if (tree.id == null || tree.title == null) return false
         if (tree.getMetadata<Any?>("hidden") != null) return false
         return upsert(TreeConfigData(tree, source, onOpen), bumpRevision)
@@ -150,12 +147,12 @@ object ConfigRegistry {
         }
     }
 
-    fun findById(id: String): ConfigData? = configList.find { it.id == id }
+    fun findById(id: String): ConfigData? = configs.find { it.id == id }
 
     fun findTree(id: String): Tree? = (findById(id) as? TreeConfigData)?.tree
 
     private fun upsert(data: ConfigData, bumpRevision: Boolean): Boolean {
-        val index = configList.indexOfFirst { it.id == data.id }
+        val index = configs.indexOfFirst { it.id == data.id }
         if (index >= 0) {
             if (configs[index].wraps(data)) return false
             configs[index] = data

--- a/modules/internal/src/main/kotlin/org/polyfrost/oneconfig/internal/ui/api/ModFavorites.kt
+++ b/modules/internal/src/main/kotlin/org/polyfrost/oneconfig/internal/ui/api/ModFavorites.kt
@@ -57,12 +57,6 @@ object ModFavorites {
 
     private val writeLock = Any()
 
-    /**
-     * Writes the file off the render thread
-     *
-     * The list is joined here, on the thread that owns it, so only finished bytes cross over and a
-     * star click never puts a disk write in the middle of the frame it happened in.
-     */
     private fun persist() {
         val bytes = favorites.joinToString("\n").toByteArray(StandardCharsets.UTF_8)
         val seq = writeSeq.incrementAndGet()

--- a/modules/internal/src/main/kotlin/org/polyfrost/oneconfig/internal/ui/api/ModFavorites.kt
+++ b/modules/internal/src/main/kotlin/org/polyfrost/oneconfig/internal/ui/api/ModFavorites.kt
@@ -5,6 +5,7 @@ import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateSetOf
 import androidx.compose.runtime.setValue
 import org.polyfrost.oneconfig.api.config.v1.ConfigManager
+import org.polyfrost.oneconfig.utils.v1.Multithreading
 import org.slf4j.LoggerFactory
 import java.nio.charset.StandardCharsets
 import java.nio.file.Files
@@ -51,19 +52,28 @@ object ModFavorites {
         persist()
     }
 
+    /**
+     * Writes the file off the render thread
+     *
+     * The list is joined here, on the thread that owns it, so only finished bytes cross over and a
+     * star click never puts a disk write in the middle of the frame it happened in.
+     */
     private fun persist() {
-        try {
-            val path = file()
-            Files.createDirectories(path.parent)
-            Files.write(
-                path,
-                favorites.joinToString("\n").toByteArray(StandardCharsets.UTF_8),
-                StandardOpenOption.CREATE,
-                StandardOpenOption.TRUNCATE_EXISTING,
-                StandardOpenOption.WRITE,
-            )
-        } catch (e: Exception) {
-            LOGGER.error("Failed to persist favorite mods", e)
+        val bytes = favorites.joinToString("\n").toByteArray(StandardCharsets.UTF_8)
+        Multithreading.submit {
+            try {
+                val path = file()
+                Files.createDirectories(path.parent)
+                Files.write(
+                    path,
+                    bytes,
+                    StandardOpenOption.CREATE,
+                    StandardOpenOption.TRUNCATE_EXISTING,
+                    StandardOpenOption.WRITE,
+                )
+            } catch (e: Exception) {
+                LOGGER.error("Failed to persist favorite mods", e)
+            }
         }
     }
 }

--- a/modules/internal/src/main/kotlin/org/polyfrost/oneconfig/internal/ui/api/ModFavorites.kt
+++ b/modules/internal/src/main/kotlin/org/polyfrost/oneconfig/internal/ui/api/ModFavorites.kt
@@ -11,6 +11,7 @@ import java.nio.charset.StandardCharsets
 import java.nio.file.Files
 import java.nio.file.Path
 import java.nio.file.StandardOpenOption
+import java.util.concurrent.atomic.AtomicLong
 
 object ModFavorites {
     private val LOGGER = LoggerFactory.getLogger("OneConfig/ModFavorites")
@@ -52,6 +53,10 @@ object ModFavorites {
         persist()
     }
 
+    private val writeSeq = AtomicLong()
+
+    private val writeLock = Any()
+
     /**
      * Writes the file off the render thread
      *
@@ -60,19 +65,23 @@ object ModFavorites {
      */
     private fun persist() {
         val bytes = favorites.joinToString("\n").toByteArray(StandardCharsets.UTF_8)
+        val seq = writeSeq.incrementAndGet()
         Multithreading.submit {
-            try {
-                val path = file()
-                Files.createDirectories(path.parent)
-                Files.write(
-                    path,
-                    bytes,
-                    StandardOpenOption.CREATE,
-                    StandardOpenOption.TRUNCATE_EXISTING,
-                    StandardOpenOption.WRITE,
-                )
-            } catch (e: Exception) {
-                LOGGER.error("Failed to persist favorite mods", e)
+            synchronized(writeLock) {
+                if (seq != writeSeq.get()) return@submit
+                try {
+                    val path = file()
+                    Files.createDirectories(path.parent)
+                    Files.write(
+                        path,
+                        bytes,
+                        StandardOpenOption.CREATE,
+                        StandardOpenOption.TRUNCATE_EXISTING,
+                        StandardOpenOption.WRITE,
+                    )
+                } catch (e: Exception) {
+                    LOGGER.error("Failed to persist favorite mods", e)
+                }
             }
         }
     }

--- a/modules/internal/src/main/kotlin/org/polyfrost/oneconfig/internal/ui/api/TreeConfigData.kt
+++ b/modules/internal/src/main/kotlin/org/polyfrost/oneconfig/internal/ui/api/TreeConfigData.kt
@@ -62,8 +62,6 @@ class TreeConfigData(
         get() = tree.getMetadata<String>("mod_card_description")?.nonBlankOrNull()
             ?: modInfo?.description?.nonBlankOrNull()
 
-    // category, version and description each scanned the whole mod list, and a tree's id and
-    // title never change, so neither does the answer
     private var resolvedModInfo: ModInfo? = null
 
     private val modInfo: ModInfo?

--- a/modules/internal/src/main/kotlin/org/polyfrost/oneconfig/internal/ui/api/TreeConfigData.kt
+++ b/modules/internal/src/main/kotlin/org/polyfrost/oneconfig/internal/ui/api/TreeConfigData.kt
@@ -62,20 +62,26 @@ class TreeConfigData(
         get() = tree.getMetadata<String>("mod_card_description")?.nonBlankOrNull()
             ?: modInfo?.description?.nonBlankOrNull()
 
+    // category, version and description each scanned the whole mod list, and a tree's id and
+    // title never change, so neither does the answer
+    private var resolvedModInfo: ModInfo? = null
+
     private val modInfo: ModInfo?
-        get() {
-            val mods = ModInfo.loadedMods
-            if (mods.isEmpty()) return null
-            val ids = listOfNotNull(
-                id.nonBlankOrNull(),
-                id.substringBeforeLast('.').nonBlankOrNull()?.takeIf { it != id },
-            )
-            for (modId in ids) {
-                mods.firstOrNull { it.id == modId }?.let { return it }
-            }
-            val name = title.asRenderText().nonBlankOrNull() ?: return null
-            return mods.firstOrNull { it.name.equals(name, ignoreCase = true) }
+        get() = resolvedModInfo ?: findModInfo()?.also { resolvedModInfo = it }
+
+    private fun findModInfo(): ModInfo? {
+        val mods = ModInfo.loadedMods
+        if (mods.isEmpty()) return null
+        val ids = listOfNotNull(
+            id.nonBlankOrNull(),
+            id.substringBeforeLast('.').nonBlankOrNull()?.takeIf { it != id },
+        )
+        for (modId in ids) {
+            mods.firstOrNull { it.id == modId }?.let { return it }
         }
+        val name = title.asRenderText().nonBlankOrNull() ?: return null
+        return mods.firstOrNull { it.name.equals(name, ignoreCase = true) }
+    }
 
     private fun String.nonBlankOrNull(): String? = trim().takeIf { it.isNotEmpty() }
 }

--- a/modules/internal/src/main/kotlin/org/polyfrost/oneconfig/internal/ui/components/Borders.kt
+++ b/modules/internal/src/main/kotlin/org/polyfrost/oneconfig/internal/ui/components/Borders.kt
@@ -82,8 +82,6 @@ fun Modifier.fadingEdges(
 ): Modifier {
     val topAlpha by animateFloatAsState(if (scrollState.canScrollBackward) 1f else 0f)
     val bottomAlpha by animateFloatAsState(if (scrollState.canScrollForward) 1f else 0f)
-    // the two brushes only depend on the size, so they are built in the cache rather than in the
-    // draw: this sits on every scrollable surface in the UI and was allocating both on every frame
     return this.drawWithCache {
         val lengthPx = length.toPx().coerceAtMost(size.height / 2f)
         val top = Brush.verticalGradient(

--- a/modules/internal/src/main/kotlin/org/polyfrost/oneconfig/internal/ui/components/Borders.kt
+++ b/modules/internal/src/main/kotlin/org/polyfrost/oneconfig/internal/ui/components/Borders.kt
@@ -5,6 +5,7 @@ import androidx.compose.foundation.ScrollState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.drawWithCache
 import androidx.compose.ui.draw.drawWithContent
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.geometry.Size
@@ -81,29 +82,28 @@ fun Modifier.fadingEdges(
 ): Modifier {
     val topAlpha by animateFloatAsState(if (scrollState.canScrollBackward) 1f else 0f)
     val bottomAlpha by animateFloatAsState(if (scrollState.canScrollForward) 1f else 0f)
-    return this.drawWithContent {
-        drawContent()
+    // the two brushes only depend on the size, so they are built in the cache rather than in the
+    // draw: this sits on every scrollable surface in the UI and was allocating both on every frame
+    return this.drawWithCache {
         val lengthPx = length.toPx().coerceAtMost(size.height / 2f)
-        if (topAlpha > 0f) {
-            drawRect(
-                brush = Brush.verticalGradient(
-                    colors = listOf(color, Color.Transparent),
-                    startY = 0f,
-                    endY = lengthPx,
-                ),
-                size = Size(size.width, lengthPx),
-                alpha = topAlpha,
-            )
-        }
-        if (bottomAlpha > 0f) {
-            drawRect(
-                brush = Brush.verticalGradient(
-                    colors = listOf(Color.Transparent, color),
-                    startY = size.height - lengthPx,
-                    endY = size.height,
-                ),
+        val top = Brush.verticalGradient(
+            colors = listOf(color, Color.Transparent),
+            startY = 0f,
+            endY = lengthPx,
+        )
+        val bottom = Brush.verticalGradient(
+            colors = listOf(Color.Transparent, color),
+            startY = size.height - lengthPx,
+            endY = size.height,
+        )
+        val edge = Size(size.width, lengthPx)
+        onDrawWithContent {
+            drawContent()
+            if (topAlpha > 0f) drawRect(brush = top, size = edge, alpha = topAlpha)
+            if (bottomAlpha > 0f) drawRect(
+                brush = bottom,
                 topLeft = Offset(0f, size.height - lengthPx),
-                size = Size(size.width, lengthPx),
+                size = edge,
                 alpha = bottomAlpha,
             )
         }

--- a/modules/internal/src/main/kotlin/org/polyfrost/oneconfig/internal/ui/components/Icon.kt
+++ b/modules/internal/src/main/kotlin/org/polyfrost/oneconfig/internal/ui/components/Icon.kt
@@ -18,8 +18,16 @@ import androidx.compose.ui.graphics.ColorFilter
 import androidx.compose.ui.graphics.ColorMatrix
 import androidx.compose.ui.graphics.FilterQuality
 import androidx.compose.ui.graphics.ImageBitmap
-import androidx.compose.ui.graphics.painter.BitmapPainter
+import androidx.compose.ui.geometry.Size
+import androidx.compose.ui.graphics.asSkiaBitmap
+import androidx.compose.ui.graphics.drawscope.DrawScope
+import androidx.compose.ui.graphics.drawscope.drawIntoCanvas
+import androidx.compose.ui.graphics.nativeCanvas
 import androidx.compose.ui.graphics.painter.Painter
+import org.jetbrains.skia.Image as SkImage
+import org.jetbrains.skia.Paint as SkPaint
+import org.jetbrains.skia.Rect as SkRect
+import org.jetbrains.skia.SamplingMode
 import androidx.compose.ui.graphics.toComposeImageBitmap
 import androidx.compose.ui.res.loadImageBitmap
 import androidx.compose.ui.unit.dp
@@ -27,6 +35,7 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import org.polyfrost.oneconfig.internal.ui.themes.Accent
 import org.polyfrost.oneconfig.internal.ui.themes.LocalTheme
+import org.polyfrost.oneconfig.utils.v1.Multithreading
 import java.io.ByteArrayInputStream
 import java.io.File
 import java.util.concurrent.ConcurrentHashMap
@@ -36,13 +45,23 @@ import kotlin.math.sqrt
 private object IconResourceMarker
 private const val DefaultIconSize = 18f
 private val DefaultRasterIconShape = RoundedCornerShape(8.dp)
+private const val SvgHeaderBytes = 512
+private val SvgViewBox = Regex("""viewBox\s*=\s*"([^"]+)"""")
+private val SvgViewBoxSeparator = Regex("""[\s,]+""")
 
 /**
  * A decoded raster icon plus the filter quality it should be scaled with
  *
  * Pixel art is upscaled with nearest neighbour so it stays crisp
  */
-private class RasterIcon(val bitmap: ImageBitmap, val filterQuality: FilterQuality)
+private class RasterIcon(val bitmap: ImageBitmap, filterQuality: FilterQuality) {
+    // Compose's bitmap painter builds a native image and destroys it on every draw, and the mod
+    // list draws over a hundred icons a frame. nothing about the image changes between them
+    val image: SkImage by lazy { SkImage.makeFromBitmap(bitmap.asSkiaBitmap()) }
+
+    val sampling: SamplingMode =
+        if (filterQuality == FilterQuality.None) SamplingMode.DEFAULT else SamplingMode.LINEAR
+}
 
 private object IconBitmapCache {
     private class Entry(val lastModified: Long, val icon: RasterIcon)
@@ -54,6 +73,53 @@ private object IconBitmapCache {
 
     fun put(key: String, lastModified: Long, icon: RasterIcon) {
         cache[key] = Entry(lastModified, icon)
+    }
+}
+
+// jar contents cannot change while the game runs, so no modification stamp. misses are cached
+// too, since theme override probes usually resolve to nothing and a scroll asks again
+private object IconResource {
+    private class Entry(val bytes: ByteArray?)
+
+    private val cache = ConcurrentHashMap<String, Entry>()
+
+    fun bytes(path: String): ByteArray? = cache.getOrPut(path) { Entry(load(path)) }.bytes
+
+    fun exists(path: String): Boolean = bytes(path) != null
+
+    // an icon shipped as a file was read from disk again on every scroll back, because the read
+    // lived in a remember the lazy grid throws away
+    fun fileBytes(file: File, stamp: Long): ByteArray? =
+        cache.getOrPut("file:${'$'}{file.path}@${'$'}stamp") {
+            Entry(runCatching { file.readBytes() }.getOrNull())
+        }.bytes
+
+    // a classpath miss walks every jar the game loaded, and most icon probes miss by design, so
+    // the first card showing a name paid for the search on the frame that showed it
+    fun warm(names: Collection<String>) {
+        // one pass at a time: the warm-up runs several times while the window settles, and threads
+        // doing this at once contend in the class loader with each other and with the render thread
+        val pending = names.filterTo(HashSet()) { !cache.containsKey(it) && warming.add(it) }
+        if (pending.isEmpty()) return
+        Multithreading.submit {
+            for (name in pending) {
+                runCatching {
+                    val file = File(name).takeIf { it.isAbsolute && it.isFile }
+                    if (file != null) fileBytes(file, file.lastModified()) else bytes(name)
+                }
+            }
+        }
+    }
+
+    /** names a warm-up already owns, so passes do not duplicate each other */
+    private val warming = ConcurrentHashMap.newKeySet<String>()
+
+    private fun load(path: String): ByteArray? {
+        val normalized = path.removePrefix("/")
+        val loader = Thread.currentThread().contextClassLoader ?: IconResourceMarker::class.java.classLoader
+        val stream = loader?.getResourceAsStream(normalized)
+            ?: IconResourceMarker::class.java.getResourceAsStream(path)
+        return stream?.use { it.readBytes() }
     }
 }
 
@@ -86,7 +152,33 @@ private fun decodeRasterIcon(bytes: ByteArray): RasterIcon {
     return RasterIcon(buffered.toComposeImageBitmap(), quality)
 }
 
-private fun rasterPainter(icon: RasterIcon) = BitmapPainter(icon.bitmap, filterQuality = icon.filterQuality)
+// raster icons are never tinted so no colour filter is carried, but alpha is, since cards fade
+private class RasterIconPainter(private val icon: RasterIcon) : Painter() {
+    private val paint = SkPaint()
+    private var alpha = 1f
+
+    override val intrinsicSize = Size(icon.bitmap.width.toFloat(), icon.bitmap.height.toFloat())
+
+    override fun applyAlpha(alpha: Float): Boolean {
+        this.alpha = alpha
+        return true
+    }
+
+    override fun DrawScope.onDraw() {
+        val image = icon.image
+        paint.setAlphaf(alpha.coerceIn(0f, 1f))
+        drawIntoCanvas {
+            it.nativeCanvas.drawImageRect(
+                image,
+                SkRect.makeWH(image.width.toFloat(), image.height.toFloat()),
+                SkRect.makeWH(size.width, size.height),
+                icon.sampling,
+                paint,
+                true,
+            )
+        }
+    }
+}
 
 @Composable
 fun Icon(
@@ -108,12 +200,15 @@ fun Icon(
         val lastModified = file.lastModified()
         if (isSvg) {
             val over = LocalUiOversample.current
-            val painter = remember(iconName, lastModified, over) {
-                runCatching { OversampledSvgPainter(file.readBytes(), over) }.getOrNull()
+            val bytes = remember(iconName, lastModified) { IconResource.fileBytes(file, lastModified) }
+            val painter = remember(bytes, over) {
+                bytes?.let {
+                    runCatching { OversampledSvgPainter(it, over, "$iconName@$lastModified") }.getOrNull()
+                }
             }
             if (painter != null) {
-                val aspectRatio = remember(iconName, lastModified) {
-                    if (fitAspectRatio) file.inputStream().buffered().use(::readSvgAspectRatio) else null
+                val aspectRatio = remember(bytes, fitAspectRatio) {
+                    if (fitAspectRatio) bytes?.let(::readSvgAspectRatio) else null
                 }
                 Image(
                     painter = painter,
@@ -128,7 +223,7 @@ fun Icon(
             val imageModifier = modifier.then(iconSizeModifier(null)).clip(DefaultRasterIconShape)
             if (icon != null) {
                 Image(
-                    painter = remember(icon) { rasterPainter(icon) },
+                    painter = remember(icon) { RasterIconPainter(icon) },
                     contentDescription = null,
                     modifier = imageModifier
                 )
@@ -142,9 +237,11 @@ fun Icon(
 
     val defaultPath = iconName.toIconResourcePath()
     val overridePath = theme.iconOverrides[iconName]?.toIconResourcePath()
-    val path = overridePath?.takeIf(::iconResourceExists) ?: defaultPath.takeIf(::iconResourceExists) ?: return
+    val path = overridePath?.takeIf(IconResource::exists) ?: defaultPath.takeIf(IconResource::exists) ?: return
     val isSvg = path.endsWith(".svg", ignoreCase = true)
-    val aspectRatio = remember(path, fitAspectRatio) { if (fitAspectRatio && isSvg) readSvgAspectRatio(path) else null }
+    val aspectRatio = remember(path, fitAspectRatio) {
+        if (fitAspectRatio && isSvg) IconResource.bytes(path)?.let(::readSvgAspectRatio) else null
+    }
     val resourceModifier = modifier.then(iconSizeModifier(aspectRatio))
     val clippedResourceModifier = if (!isSvg) {
         resourceModifier.clip(DefaultRasterIconShape)
@@ -152,7 +249,7 @@ fun Icon(
         resourceModifier
     }
     val painter = if (isSvg) {
-        rememberIconSvgPainter(path) ?: return
+        rememberSvgResourcePainter(path) ?: return
     } else {
         rememberIconRasterPainter(path) ?: run {
             // keeps the icon's space reserved while it decodes in the background
@@ -168,19 +265,13 @@ fun Icon(
     )
 }
 
-@Composable
-private fun rememberIconSvgPainter(path: String): Painter? {
-    val over = LocalUiOversample.current
-    return remember(path, over) {
-        readIconResourceBytes(path)?.let { OversampledSvgPainter(it, over) }
-    }
-}
-
+// a painter per call site, not cached: it stores the alpha and colour filter applied to it and
+// callers tint the same icon differently
 @Composable
 fun rememberSvgResourcePainter(path: String): Painter? {
     val over = LocalUiOversample.current
     return remember(path, over) {
-        readIconResourceBytes(path)?.let { OversampledSvgPainter(it, over) }
+        IconResource.bytes(path)?.let { OversampledSvgPainter(it, over, path) }
     }
 }
 
@@ -192,7 +283,7 @@ private val brandFillPeakCache = ConcurrentHashMap<String, Float>()
 private val hexColorRegex = Regex("#([0-9a-fA-F]{6})\\b")
 
 private fun brandFillPeak(path: String): Float = brandFillPeakCache.getOrPut(path) {
-    val svg = readIconResourceBytes(path)?.toString(Charsets.UTF_8) ?: return@getOrPut 0f
+    val svg = IconResource.bytes(path)?.toString(Charsets.UTF_8) ?: return@getOrPut 0f
     hexColorRegex.findAll(svg).mapNotNull { match ->
         val rgb = match.groupValues[1].toInt(16)
         val r = (rgb shr 16 and 0xFF) / 255f
@@ -221,36 +312,23 @@ fun rememberBrandTint(path: String, tint: Color): ColorFilter? = remember(path, 
 
 @Composable
 private fun rememberIconRasterPainter(path: String): Painter? {
-    val icon = rememberAsyncRasterIcon(path, 0L) { readIconResourceBytes(path) }
-    return icon?.let { remember(it) { rasterPainter(it) } }
+    val icon = rememberAsyncRasterIcon(path, 0L) { IconResource.bytes(path) }
+    return icon?.let { remember(it) { RasterIconPainter(it) } }
 }
 
-private fun readIconResourceBytes(path: String): ByteArray? {
-    val normalized = path.removePrefix("/")
-    val loader = Thread.currentThread().contextClassLoader ?: IconResourceMarker::class.java.classLoader
-    val stream = loader?.getResourceAsStream(normalized)
-        ?: IconResourceMarker::class.java.getResourceAsStream(path)
-    return stream?.use { it.readBytes() }
-}
+/** resolves [names] on a background thread before anything draws them. safe to call repeatedly */
+fun warmIconCache(names: Collection<String>) = IconResource.warm(names)
 
 fun canRenderIcon(iconName: String): Boolean {
     if (iconName.contains('/') || iconName.contains('.')) {
         val file = File(iconName)
         if (file.isAbsolute) return file.isFile
     }
-    return iconResourceExists(iconName.toIconResourcePath())
+    return IconResource.exists(iconName.toIconResourcePath())
 }
 
 private fun String.toIconResourcePath(): String =
     if (contains('/') || contains('.')) this else "/assets/oneconfig/ico/$this.svg"
-
-private val iconResourceExistsCache = ConcurrentHashMap<String, Boolean>()
-
-private fun iconResourceExists(path: String): Boolean = iconResourceExistsCache.getOrPut(path) {
-    val normalized = path.removePrefix("/")
-    Thread.currentThread().contextClassLoader?.getResource(normalized) != null ||
-        IconResourceMarker::class.java.classLoader?.getResource(normalized) != null
-}
 
 private fun iconSizeModifier(aspectRatio: Float?): Modifier {
     val ratio = aspectRatio?.takeIf { it.isFinite() && it > 0f } ?: 1f
@@ -258,17 +336,11 @@ private fun iconSizeModifier(aspectRatio: Float?): Modifier {
     return Modifier.size((DefaultIconSize * scale).dp, (DefaultIconSize / scale).dp)
 }
 
-private fun readSvgAspectRatio(path: String): Float? {
-    val normalized = path.removePrefix("/")
-    val loader = Thread.currentThread().contextClassLoader ?: IconResourceMarker::class.java.classLoader
-    return loader.getResourceAsStream(normalized)?.buffered()?.use(::readSvgAspectRatio)
-        ?: IconResourceMarker::class.java.classLoader?.getResourceAsStream(normalized)?.buffered()?.use(::readSvgAspectRatio)
-}
-
-private fun readSvgAspectRatio(stream: java.io.InputStream): Float? {
-    val header = stream.reader().use { it.readText().take(512) }
-    val viewBox = Regex("""viewBox\s*=\s*"([^"]+)"""").find(header)?.groupValues?.get(1) ?: return null
-    val values = viewBox.trim().split(Regex("""[\s,]+""")).mapNotNull { it.toFloatOrNull() }
+/** the viewBox sits in the opening tag, so only the head is worth decoding */
+private fun readSvgAspectRatio(bytes: ByteArray): Float? {
+    val header = String(bytes, 0, minOf(bytes.size, SvgHeaderBytes), Charsets.UTF_8)
+    val viewBox = SvgViewBox.find(header)?.groupValues?.get(1) ?: return null
+    val values = viewBox.trim().split(SvgViewBoxSeparator).mapNotNull { it.toFloatOrNull() }
     if (values.size < 4) return null
     val width = values[2]
     val height = values[3]
@@ -285,7 +357,7 @@ fun IconWithIndicator(
 ) {
     val resolvedColor = if (color == Color.Unspecified) LocalTheme.current.textColor else color
     Box {
-        val painter = rememberIconSvgPainter("/assets/oneconfig/ico/$iconName.svg")
+        val painter = rememberSvgResourcePainter("/assets/oneconfig/ico/$iconName.svg")
         if (painter != null) Image(
             painter = painter,
             contentDescription = null,

--- a/modules/internal/src/main/kotlin/org/polyfrost/oneconfig/internal/ui/components/Icon.kt
+++ b/modules/internal/src/main/kotlin/org/polyfrost/oneconfig/internal/ui/components/Icon.kt
@@ -90,7 +90,7 @@ private object IconResource {
     // an icon shipped as a file was read from disk again on every scroll back, because the read
     // lived in a remember the lazy grid throws away
     fun fileBytes(file: File, stamp: Long): ByteArray? =
-        cache.getOrPut("file:${'$'}{file.path}@${'$'}stamp") {
+        cache.getOrPut("file:${file.path}@$stamp") {
             Entry(runCatching { file.readBytes() }.getOrNull())
         }.bytes
 

--- a/modules/internal/src/main/kotlin/org/polyfrost/oneconfig/internal/ui/components/Icon.kt
+++ b/modules/internal/src/main/kotlin/org/polyfrost/oneconfig/internal/ui/components/Icon.kt
@@ -55,8 +55,6 @@ private val SvgViewBoxSeparator = Regex("""[\s,]+""")
  * Pixel art is upscaled with nearest neighbour so it stays crisp
  */
 private class RasterIcon(val bitmap: ImageBitmap, filterQuality: FilterQuality) {
-    // Compose's bitmap painter builds a native image and destroys it on every draw, and the mod
-    // list draws over a hundred icons a frame. nothing about the image changes between them
     val image: SkImage by lazy { SkImage.makeFromBitmap(bitmap.asSkiaBitmap()) }
 
     val sampling: SamplingMode =
@@ -76,8 +74,6 @@ private object IconBitmapCache {
     }
 }
 
-// jar contents cannot change while the game runs, so no modification stamp. misses are cached
-// too, since theme override probes usually resolve to nothing and a scroll asks again
 private object IconResource {
     private class Entry(val bytes: ByteArray?)
 
@@ -87,18 +83,12 @@ private object IconResource {
 
     fun exists(path: String): Boolean = bytes(path) != null
 
-    // an icon shipped as a file was read from disk again on every scroll back, because the read
-    // lived in a remember the lazy grid throws away
     fun fileBytes(file: File, stamp: Long): ByteArray? =
         cache.getOrPut("file:${file.path}@$stamp") {
             Entry(runCatching { file.readBytes() }.getOrNull())
         }.bytes
 
-    // a classpath miss walks every jar the game loaded, and most icon probes miss by design, so
-    // the first card showing a name paid for the search on the frame that showed it
     fun warm(names: Collection<String>) {
-        // one pass at a time: the warm-up runs several times while the window settles, and threads
-        // doing this at once contend in the class loader with each other and with the render thread
         val pending = names.filterTo(HashSet()) { !cache.containsKey(it) && warming.add(it) }
         if (pending.isEmpty()) return
         Multithreading.submit {
@@ -111,7 +101,6 @@ private object IconResource {
         }
     }
 
-    /** names a warm-up already owns, so passes do not duplicate each other */
     private val warming = ConcurrentHashMap.newKeySet<String>()
 
     private fun load(path: String): ByteArray? {
@@ -152,7 +141,6 @@ private fun decodeRasterIcon(bytes: ByteArray): RasterIcon {
     return RasterIcon(buffered.toComposeImageBitmap(), quality)
 }
 
-// raster icons are never tinted so no colour filter is carried, but alpha is, since cards fade
 private class RasterIconPainter(private val icon: RasterIcon) : Painter() {
     private val paint = SkPaint()
     private var alpha = 1f
@@ -265,8 +253,6 @@ fun Icon(
     )
 }
 
-// a painter per call site, not cached: it stores the alpha and colour filter applied to it and
-// callers tint the same icon differently
 @Composable
 fun rememberSvgResourcePainter(path: String): Painter? {
     val over = LocalUiOversample.current
@@ -316,7 +302,6 @@ private fun rememberIconRasterPainter(path: String): Painter? {
     return icon?.let { remember(it) { RasterIconPainter(it) } }
 }
 
-/** resolves [names] on a background thread before anything draws them. safe to call repeatedly */
 fun warmIconCache(names: Collection<String>) = IconResource.warm(names)
 
 fun canRenderIcon(iconName: String): Boolean {
@@ -336,7 +321,6 @@ private fun iconSizeModifier(aspectRatio: Float?): Modifier {
     return Modifier.size((DefaultIconSize * scale).dp, (DefaultIconSize / scale).dp)
 }
 
-/** the viewBox sits in the opening tag, so only the head is worth decoding */
 private fun readSvgAspectRatio(bytes: ByteArray): Float? {
     val header = String(bytes, 0, minOf(bytes.size, SvgHeaderBytes), Charsets.UTF_8)
     val viewBox = SvgViewBox.find(header)?.groupValues?.get(1) ?: return null

--- a/modules/internal/src/main/kotlin/org/polyfrost/oneconfig/internal/ui/components/OversampledSvg.kt
+++ b/modules/internal/src/main/kotlin/org/polyfrost/oneconfig/internal/ui/components/OversampledSvg.kt
@@ -49,22 +49,15 @@ import kotlin.math.max
 
 val LocalUiOversample = staticCompositionLocalOf { 1f }
 
-// the painter and its DOM cannot be shared, but the bitmap they produce can: it is immutable and
-// the tint is a draw time filter, so one raster serves every call site whatever colour it draws
 private val svgRasters = ConcurrentHashMap<String, ImageBitmap>()
 
-// rasterising overwrites the width and height it is read from, so the size is kept separately
-// and only the first painter for an icon pays for it
 private val svgSizes = ConcurrentHashMap<String, Size>()
 
 class OversampledSvgPainter(
     private val bytes: ByteArray,
     private val oversample: Float,
-    /** identifies the source so rasters and sizes can be shared, null disables sharing */
     private val cacheKey: String? = null,
 ) : Painter() {
-    // parsed on first use, not on construction: a scroll back builds a new painter, and a cached
-    // raster needs no document at all
     private val dom: SVGDOM by lazy {
         SVGDOM(Data.makeFromBytes(bytes)).also { parsed ->
             val r = parsed.root ?: return@also

--- a/modules/internal/src/main/kotlin/org/polyfrost/oneconfig/internal/ui/components/OversampledSvg.kt
+++ b/modules/internal/src/main/kotlin/org/polyfrost/oneconfig/internal/ui/components/OversampledSvg.kt
@@ -28,7 +28,6 @@ package org.polyfrost.oneconfig.internal.ui.components
 
 import androidx.compose.runtime.staticCompositionLocalOf
 import androidx.compose.ui.geometry.Size
-import androidx.compose.ui.geometry.isSpecified
 import androidx.compose.ui.graphics.ColorFilter
 import androidx.compose.ui.graphics.FilterQuality
 import androidx.compose.ui.graphics.ImageBitmap
@@ -40,6 +39,7 @@ import org.jetbrains.skia.Data
 import org.jetbrains.skia.Rect
 import org.jetbrains.skia.Surface
 import org.jetbrains.skia.svg.SVGDOM
+import java.util.concurrent.ConcurrentHashMap
 import org.jetbrains.skia.svg.SVGLength
 import org.jetbrains.skia.svg.SVGLengthUnit
 import org.jetbrains.skia.svg.SVGPreserveAspectRatio
@@ -49,24 +49,41 @@ import kotlin.math.max
 
 val LocalUiOversample = staticCompositionLocalOf { 1f }
 
+// the painter and its DOM cannot be shared, but the bitmap they produce can: it is immutable and
+// the tint is a draw time filter, so one raster serves every call site whatever colour it draws
+private val svgRasters = ConcurrentHashMap<String, ImageBitmap>()
+
+// rasterising overwrites the width and height it is read from, so the size is kept separately
+// and only the first painter for an icon pays for it
+private val svgSizes = ConcurrentHashMap<String, Size>()
+
 class OversampledSvgPainter(
-    bytes: ByteArray,
+    private val bytes: ByteArray,
     private val oversample: Float,
+    /** identifies the source so rasters and sizes can be shared, null disables sharing */
+    private val cacheKey: String? = null,
 ) : Painter() {
-    private val dom = SVGDOM(Data.makeFromBytes(bytes))
-    private val root = dom.root
-
-    private val defaultSize: Size = run {
-        val w = root?.width?.withUnit(SVGLengthUnit.PX)?.value ?: 0f
-        val h = root?.height?.withUnit(SVGLengthUnit.PX)?.value ?: 0f
-        if (w > 0f && h > 0f) Size(w, h) else Size.Unspecified
-    }
-
-    init {
-        if (root?.viewBox == null && defaultSize.isSpecified) {
-            root?.viewBox = Rect.makeXYWH(0f, 0f, defaultSize.width, defaultSize.height)
+    // parsed on first use, not on construction: a scroll back builds a new painter, and a cached
+    // raster needs no document at all
+    private val dom: SVGDOM by lazy {
+        SVGDOM(Data.makeFromBytes(bytes)).also { parsed ->
+            val r = parsed.root ?: return@also
+            if (r.viewBox != null) return@also
+            val w = r.width.withUnit(SVGLengthUnit.PX).value
+            val h = r.height.withUnit(SVGLengthUnit.PX).value
+            if (w > 0f && h > 0f) r.viewBox = Rect.makeXYWH(0f, 0f, w, h)
         }
     }
+
+    private fun measure(): Size {
+        val r = dom.root
+        val w = r?.width?.withUnit(SVGLengthUnit.PX)?.value ?: 0f
+        val h = r?.height?.withUnit(SVGLengthUnit.PX)?.value ?: 0f
+        return if (w > 0f && h > 0f) Size(w, h) else Size.Unspecified
+    }
+
+    private val defaultSize: Size =
+        if (cacheKey == null) measure() else svgSizes.getOrPut(cacheKey, ::measure)
 
     override val intrinsicSize: Size get() = defaultSize
 
@@ -93,7 +110,9 @@ class OversampledSvgPainter(
         val key = pw.toLong() shl 32 or ph.toLong()
         var img = cached
         if (img == null || cachedKey != key) {
-            img = rasterize(pw, ph)
+            val shared = cacheKey
+            img = if (shared == null) rasterize(pw, ph)
+            else svgRasters.getOrPut("$shared@${pw}x$ph") { rasterize(pw, ph) }
             cached = img
             cachedKey = key
         }
@@ -108,6 +127,7 @@ class OversampledSvgPainter(
 
     private fun rasterize(pw: Int, ph: Int): ImageBitmap {
         val surface = Surface.makeRasterN32Premul(pw, ph)
+        val root = dom.root
         root?.width = SVGLength(pw.toFloat(), SVGLengthUnit.PX)
         root?.height = SVGLength(ph.toFloat(), SVGLengthUnit.PX)
         root?.preserveAspectRatio = SVGPreserveAspectRatio(SVGPreserveAspectRatioAlign.NONE)

--- a/modules/internal/src/main/kotlin/org/polyfrost/oneconfig/internal/ui/components/ReorderableGrid.kt
+++ b/modules/internal/src/main/kotlin/org/polyfrost/oneconfig/internal/ui/components/ReorderableGrid.kt
@@ -219,8 +219,6 @@ fun rememberGridReorderState(
  */
 @Composable
 fun Modifier.reorderableItem(state: GridReorderState, key: Any): Modifier = this
-    // the layer caches the card's rasterised content, so a frame that changed nothing replays it
-    // instead of drawing the card again
     .graphicsLayer { alpha = if (state.overlayKey == key) 0f else 1f }
     .pointerInput(key, state) {
         detectDragGestures(

--- a/modules/internal/src/main/kotlin/org/polyfrost/oneconfig/internal/ui/components/ReorderableGrid.kt
+++ b/modules/internal/src/main/kotlin/org/polyfrost/oneconfig/internal/ui/components/ReorderableGrid.kt
@@ -219,6 +219,8 @@ fun rememberGridReorderState(
  */
 @Composable
 fun Modifier.reorderableItem(state: GridReorderState, key: Any): Modifier = this
+    // the layer caches the card's rasterised content, so a frame that changed nothing replays it
+    // instead of drawing the card again
     .graphicsLayer { alpha = if (state.overlayKey == key) 0f else 1f }
     .pointerInput(key, state) {
         detectDragGestures(

--- a/modules/internal/src/main/kotlin/org/polyfrost/oneconfig/internal/ui/components/RetainedVisibility.kt
+++ b/modules/internal/src/main/kotlin/org/polyfrost/oneconfig/internal/ui/components/RetainedVisibility.kt
@@ -1,0 +1,50 @@
+package org.polyfrost.oneconfig.internal.ui.components
+
+import androidx.compose.animation.core.FiniteAnimationSpec
+import androidx.compose.animation.core.Transition
+import androidx.compose.animation.core.animateFloat
+import androidx.compose.animation.core.updateTransition
+import androidx.compose.foundation.layout.Box
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.graphicsLayer
+
+/**
+ * fades and scales [content] in and out, and keeps it composed while it is hidden
+ *
+ * AnimatedVisibility disposes its content when the exit ends, which for a retained scene hands
+ * back the whole cost of an open. this animates the same way and simply stops drawing.
+ *
+ * the chain is the same shape either way on purpose: a modifier that comes and goes adds and
+ * removes nodes Compose indexes for hit testing, and toggling one took the scene down.
+ */
+@Composable
+fun RetainedVisibility(
+    visible: Boolean,
+    enter: FiniteAnimationSpec<Float>,
+    exit: FiniteAnimationSpec<Float>,
+    modifier: Modifier = Modifier,
+    alphaMultiplier: Float = 1f,
+    hiddenScale: Float = 0.9f,
+    content: @Composable (alpha: Float) -> Unit,
+) {
+    val transition = updateTransition(visible, label = "retainedVisibility")
+    val spec: @Composable Transition.Segment<Boolean>.() -> FiniteAnimationSpec<Float> = {
+        if (targetState) enter else exit
+    }
+    val progress by transition.animateFloat(spec, "retainedVisibilityAlpha") { if (it) 1f else 0f }
+    val scale by transition.animateFloat(spec, "retainedVisibilityScale") { if (it) 1f else hiddenScale }
+
+    val alpha = progress * alphaMultiplier
+    Box(
+        modifier = modifier
+            .graphicsLayer {
+                this.alpha = alpha
+                scaleX = scale
+                scaleY = scale
+            }
+    ) {
+        content(alpha)
+    }
+}

--- a/modules/internal/src/main/kotlin/org/polyfrost/oneconfig/internal/ui/components/RetainedVisibility.kt
+++ b/modules/internal/src/main/kotlin/org/polyfrost/oneconfig/internal/ui/components/RetainedVisibility.kt
@@ -10,15 +10,6 @@ import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.graphicsLayer
 
-/**
- * fades and scales [content] in and out, and keeps it composed while it is hidden
- *
- * AnimatedVisibility disposes its content when the exit ends, which for a retained scene hands
- * back the whole cost of an open. this animates the same way and simply stops drawing.
- *
- * the chain is the same shape either way on purpose: a modifier that comes and goes adds and
- * removes nodes Compose indexes for hit testing, and toggling one took the scene down.
- */
 @Composable
 fun RetainedVisibility(
     visible: Boolean,

--- a/modules/internal/src/main/kotlin/org/polyfrost/oneconfig/internal/ui/components/settings/KeybindConflicts.kt
+++ b/modules/internal/src/main/kotlin/org/polyfrost/oneconfig/internal/ui/components/settings/KeybindConflicts.kt
@@ -3,12 +3,17 @@ package org.polyfrost.oneconfig.internal.ui.components.settings
 import androidx.compose.runtime.mutableIntStateOf
 import org.polyfrost.oneconfig.api.config.v1.Property
 import org.polyfrost.oneconfig.api.ui.v1.keybind.OneConfigKeybind
+import org.polyfrost.oneconfig.internal.ui.api.ConfigRegistry
 import org.polyfrost.oneconfig.internal.ui.components.asRenderText
 import org.polyfrost.oneconfig.internal.ui.components.localizedTitle
+import org.polyfrost.oneconfig.internal.ui.keybind.KeybindProviderRegistry
 import org.polyfrost.oneconfig.internal.ui.keybind.collectAllKeybindGroups
 
 internal object KeybindConflicts {
     val revision = mutableIntStateOf(0)
+
+    private var cachedKey = Long.MIN_VALUE
+    private var cached: Map<Property<*>, List<Property<*>>> = emptyMap()
 
     private fun boundKeybinds(): List<Pair<Property<*>, OneConfigKeybind>> {
         return collectAllKeybindGroups().flatMap { group ->
@@ -20,7 +25,23 @@ internal object KeybindConflicts {
         }
     }
 
+    /**
+     * Comparing every bound keybind against every other is far too expensive to redo per row per
+     * recomposition, so the result is held until one of the revisions that could change it moves
+     *
+     * Reading those revisions here subscribes the caller to them, so nobody has to name them
+     */
     fun conflictMap(): Map<Property<*>, List<Property<*>>> {
+        val key = (ConfigRegistry.revision * 31L + KeybindProviderRegistry.revision.intValue) * 31 +
+            revision.intValue
+        if (key != cachedKey) {
+            cached = computeConflictMap()
+            cachedKey = key
+        }
+        return cached
+    }
+
+    private fun computeConflictMap(): Map<Property<*>, List<Property<*>>> {
         val bound = boundKeybinds()
         if (bound.size < 2) return emptyMap()
         val conflicting = HashMap<Property<*>, MutableList<Property<*>>>()

--- a/modules/internal/src/main/kotlin/org/polyfrost/oneconfig/internal/ui/components/settings/KeybindConflicts.kt
+++ b/modules/internal/src/main/kotlin/org/polyfrost/oneconfig/internal/ui/components/settings/KeybindConflicts.kt
@@ -25,12 +25,6 @@ internal object KeybindConflicts {
         }
     }
 
-    /**
-     * Comparing every bound keybind against every other is far too expensive to redo per row per
-     * recomposition, so the result is held until one of the revisions that could change it moves
-     *
-     * Reading those revisions here subscribes the caller to them, so nobody has to name them
-     */
     fun conflictMap(): Map<Property<*>, List<Property<*>>> {
         val key = (ConfigRegistry.revision * 31L + KeybindProviderRegistry.revision.intValue) * 31 +
             revision.intValue

--- a/modules/internal/src/main/kotlin/org/polyfrost/oneconfig/internal/ui/components/settings/KeybindOption.kt
+++ b/modules/internal/src/main/kotlin/org/polyfrost/oneconfig/internal/ui/components/settings/KeybindOption.kt
@@ -43,7 +43,6 @@ import org.polyfrost.oneconfig.api.platform.v1.Platform
 import org.polyfrost.oneconfig.api.ui.v1.keybind.KeybindManager
 import org.polyfrost.oneconfig.api.ui.v1.keybind.KeyModifiers
 import org.polyfrost.oneconfig.api.ui.v1.keybind.OneConfigKeybind
-import org.polyfrost.oneconfig.internal.ui.api.ConfigRegistry
 import org.polyfrost.oneconfig.internal.ui.keybind.KeybindRecordingBus
 import org.polyfrost.oneconfig.internal.ui.api.settings.KeybindOptionData
 import org.polyfrost.oneconfig.internal.ui.components.Icon
@@ -141,9 +140,7 @@ fun KeybindOption(data: KeybindOptionData) {
     val recordedMouse = remember(data.prop) { mutableStateListOf<Int>() }
     val heldMouse = remember(data.prop) { HashSet<Int>() }
 
-    val hasConflict = (KeybindConflicts.revision.intValue + ConfigRegistry.revision).let {
-        !recording && data.prop in KeybindConflicts.conflictingProps()
-    }
+    val hasConflict = !recording && data.prop in KeybindConflicts.conflictingProps()
 
     // setting the property may mutate the keybind in place or swap in a fresh instance and
     // KeybindManager.replace handles both so the bind keeps firing without a mod change callback

--- a/modules/internal/src/main/kotlin/org/polyfrost/oneconfig/internal/ui/hud/HudModCardData.kt
+++ b/modules/internal/src/main/kotlin/org/polyfrost/oneconfig/internal/ui/hud/HudModCardData.kt
@@ -33,7 +33,7 @@ private fun withHudSuffix(title: Any): Any {
 private fun findOwner(ownerId: String): ConfigData? =
     ConfigRegistry.findById(ownerId)
         ?: ConfigRegistry.findById("$ownerId.json")
-        ?: ConfigRegistry.configList.firstOrNull { it.id.substringBefore('/').removeSuffix(".json") == ownerId }
+        ?: ConfigRegistry.configs.firstOrNull { it.id.substringBefore('/').removeSuffix(".json") == ownerId }
 
 private fun ownerVisible(ownerId: String, owner: ConfigData?): Boolean {
     if (ownerId == BUILTIN_HUD_CONFIG_ID) return true

--- a/modules/internal/src/main/kotlin/org/polyfrost/oneconfig/internal/ui/hud/HudModInfo.kt
+++ b/modules/internal/src/main/kotlin/org/polyfrost/oneconfig/internal/ui/hud/HudModInfo.kt
@@ -9,7 +9,7 @@ internal fun configForHud(configId: String): ConfigData? {
     val modId = configId.removeSuffix(".json").substringBefore('/')
     return ConfigRegistry.findById(configId)
         ?: ConfigRegistry.findById("$configId.json")
-        ?: ConfigRegistry.configList.firstOrNull { it.id.removeSuffix(".json") == modId }
+        ?: ConfigRegistry.configs.firstOrNull { it.id.removeSuffix(".json") == modId }
 }
 
 internal fun modNameFor(configId: String): String? {

--- a/modules/internal/src/main/kotlin/org/polyfrost/oneconfig/internal/ui/hud/components/HudPreview.kt
+++ b/modules/internal/src/main/kotlin/org/polyfrost/oneconfig/internal/ui/hud/components/HudPreview.kt
@@ -5,8 +5,8 @@ import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.size
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.snapshots.Snapshot
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -29,6 +29,7 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import org.apache.logging.log4j.LogManager
 import org.polyfrost.compose.render.RenderContext
+import org.polyfrost.compose.runtime.PolyComposeHost
 import org.polyfrost.compose.runtime.PolyComposeRuntime
 import org.polyfrost.oneconfig.api.hud.v1.Hud
 import org.polyfrost.oneconfig.api.hud.v1.HudManager
@@ -53,15 +54,26 @@ internal class HudPreviewState(val runtime: PolyComposeRuntime) {
     val ready: Boolean get() = naturalWidth > 0f && naturalHeight > 0f
 }
 
-@Composable
-internal fun rememberHudPreview(hud: Hud): HudPreviewState {
-    val revision = HudManager.revision
-    val state = remember(hud, revision) {
-        hud.update()
-        HudPreviewState(PolyComposeRuntime().also { rt -> rt.setContent { hud.Content() } })
+// a lazy grid disposes cards that scroll out of view, so without this every scroll back rebuilds
+// the runtime and re-runs setContent, which is the most expensive thing a card does
+private object HudPreviewCache {
+    private val cache = HashMap<Hud, HudPreviewState>()
+    private var generation = Int.MIN_VALUE
+
+    internal fun get(hud: Hud, revision: Int, build: () -> HudPreviewState): HudPreviewState {
+        // a revision means providers were registered, unregistered or reloaded, so every preview
+        // here mirrors a HUD that may no longer exist
+        if (revision != generation) {
+            releaseAll()
+            generation = revision
+        }
+        return cache.getOrPut(hud, build)
     }
-    DisposableEffect(state) {
-        onDispose {
+
+    /** called when a revision says the HUDs these mirror have been replaced */
+    private fun releaseAll() {
+        if (cache.isEmpty()) return
+        for (state in cache.values) {
             try {
                 state.runtime.dispose()
             } catch (failure: Throwable) {
@@ -69,8 +81,27 @@ internal fun rememberHudPreview(hud: Hud): HudPreviewState {
                 LOGGER.warn("Failed to dispose HUD preview", failure)
             }
         }
+        cache.clear()
+    }
+}
+
+@Composable
+internal fun rememberHudPreview(hud: Hud): HudPreviewState {
+    val revision = HudManager.revision
+    // owned by HudPreviewCache, so a card scrolling out of view must not take the runtime with it
+    val state = remember(hud, revision) {
+        HudPreviewCache.get(hud, revision) {
+            hud.update()
+            HudPreviewState(
+                PolyComposeRuntime(PolyComposeHost.previews).also { rt ->
+                    rt.setContent { hud.Content() }
+                }
+            )
+        }
     }
     LaunchedEffect(state) {
+        // a cached runtime is already measured, and its content cannot change without a revision
+        if (state.ready) return@LaunchedEffect
         hud.update()
         if (hud.staticWidth && hud.staticW > 0f && hud.staticH > 0f) {
             state.runtime.frame(hud.staticW, hud.staticH)
@@ -98,7 +129,11 @@ internal fun HudPreviewCanvas(state: HudPreviewState, scale: Float, modifier: Mo
             skia.save()
             skia.clipRect(org.jetbrains.skia.Rect.makeWH(size.width, size.height))
             skia.scale(scale, scale)
-            state.runtime.root.render(RenderContext(skia))
+            // a HUD reads live values, and reading them in the draw scope makes this layer depend
+            // on them, so a ticking clock redrew the whole interface. it still draws current values
+            Snapshot.withoutReadObservation {
+                state.runtime.root.render(RenderContext(skia))
+            }
             skia.restore()
         }
     }

--- a/modules/internal/src/main/kotlin/org/polyfrost/oneconfig/internal/ui/hud/components/HudPreview.kt
+++ b/modules/internal/src/main/kotlin/org/polyfrost/oneconfig/internal/ui/hud/components/HudPreview.kt
@@ -124,6 +124,9 @@ internal fun hudPreviewScale(naturalW: Float, naturalH: Float, availableW: Float
 @Composable
 internal fun HudPreviewCanvas(state: HudPreviewState, scale: Float, modifier: Modifier = Modifier) {
     Canvas(modifier) {
+        // read in the draw on purpose: this one revision is what the layer depends on, instead of
+        // every live value the HUD reads, which is what redrew the whole interface
+        HudManager.previewRevision.intValue
         drawIntoCanvas { canvas ->
             val skia = canvas.skiaCanvas
             skia.save()

--- a/modules/internal/src/main/kotlin/org/polyfrost/oneconfig/internal/ui/hud/components/HudPreview.kt
+++ b/modules/internal/src/main/kotlin/org/polyfrost/oneconfig/internal/ui/hud/components/HudPreview.kt
@@ -54,15 +54,11 @@ internal class HudPreviewState(val runtime: PolyComposeRuntime) {
     val ready: Boolean get() = naturalWidth > 0f && naturalHeight > 0f
 }
 
-// a lazy grid disposes cards that scroll out of view, so without this every scroll back rebuilds
-// the runtime and re-runs setContent, which is the most expensive thing a card does
 private object HudPreviewCache {
     private val cache = HashMap<Hud, HudPreviewState>()
     private var generation = Int.MIN_VALUE
 
     internal fun get(hud: Hud, revision: Int, build: () -> HudPreviewState): HudPreviewState {
-        // a revision means providers were registered, unregistered or reloaded, so every preview
-        // here mirrors a HUD that may no longer exist
         if (revision != generation) {
             releaseAll()
             generation = revision
@@ -70,7 +66,6 @@ private object HudPreviewCache {
         return cache.getOrPut(hud, build)
     }
 
-    /** called when a revision says the HUDs these mirror have been replaced */
     private fun releaseAll() {
         if (cache.isEmpty()) return
         for (state in cache.values) {
@@ -88,7 +83,6 @@ private object HudPreviewCache {
 @Composable
 internal fun rememberHudPreview(hud: Hud): HudPreviewState {
     val revision = HudManager.revision
-    // owned by HudPreviewCache, so a card scrolling out of view must not take the runtime with it
     val state = remember(hud, revision) {
         HudPreviewCache.get(hud, revision) {
             hud.update()
@@ -100,7 +94,6 @@ internal fun rememberHudPreview(hud: Hud): HudPreviewState {
         }
     }
     LaunchedEffect(state) {
-        // a cached runtime is already measured, and its content cannot change without a revision
         if (state.ready) return@LaunchedEffect
         hud.update()
         if (hud.staticWidth && hud.staticW > 0f && hud.staticH > 0f) {
@@ -124,16 +117,12 @@ internal fun hudPreviewScale(naturalW: Float, naturalH: Float, availableW: Float
 @Composable
 internal fun HudPreviewCanvas(state: HudPreviewState, scale: Float, modifier: Modifier = Modifier) {
     Canvas(modifier) {
-        // read in the draw on purpose: this one revision is what the layer depends on, instead of
-        // every live value the HUD reads, which is what redrew the whole interface
         HudManager.previewRevision.intValue
         drawIntoCanvas { canvas ->
             val skia = canvas.skiaCanvas
             skia.save()
             skia.clipRect(org.jetbrains.skia.Rect.makeWH(size.width, size.height))
             skia.scale(scale, scale)
-            // a HUD reads live values, and reading them in the draw scope makes this layer depend
-            // on them, so a ticking clock redrew the whole interface. it still draws current values
             Snapshot.withoutReadObservation {
                 state.runtime.root.render(RenderContext(skia))
             }

--- a/modules/internal/src/main/kotlin/org/polyfrost/oneconfig/internal/ui/hud/screens/HudDesignStudio.kt
+++ b/modules/internal/src/main/kotlin/org/polyfrost/oneconfig/internal/ui/hud/screens/HudDesignStudio.kt
@@ -412,12 +412,6 @@ private fun hitTestAnchorPoint(
     return best
 }
 
-/**
- * Paints the HUDs as they are right now, without subscribing to what they read
- *
- * This runs in the draw scope, where a read is recorded as something the layer depends on, so a
- * ticking clock invalidated the layer and one invalidated layer redraws the whole editor.
- */
 private fun drawHudContents(sk: org.jetbrains.skia.Canvas, mcToScreen: Float) =
     androidx.compose.runtime.snapshots.Snapshot.withoutReadObservation {
         drawHudContentsNow(sk, mcToScreen)

--- a/modules/internal/src/main/kotlin/org/polyfrost/oneconfig/internal/ui/hud/screens/HudDesignStudio.kt
+++ b/modules/internal/src/main/kotlin/org/polyfrost/oneconfig/internal/ui/hud/screens/HudDesignStudio.kt
@@ -412,7 +412,18 @@ private fun hitTestAnchorPoint(
     return best
 }
 
-private fun drawHudContents(sk: org.jetbrains.skia.Canvas, mcToScreen: Float) {
+/**
+ * Paints the HUDs as they are right now, without subscribing to what they read
+ *
+ * This runs in the draw scope, where a read is recorded as something the layer depends on, so a
+ * ticking clock invalidated the layer and one invalidated layer redraws the whole editor.
+ */
+private fun drawHudContents(sk: org.jetbrains.skia.Canvas, mcToScreen: Float) =
+    androidx.compose.runtime.snapshots.Snapshot.withoutReadObservation {
+        drawHudContentsNow(sk, mcToScreen)
+    }
+
+private fun drawHudContentsNow(sk: org.jetbrains.skia.Canvas, mcToScreen: Float) {
     // HUDs fused with a neighbour do not paint their own background so the merged shapes are laid down
     // here first just like the in-game HUD pass
     sk.save()
@@ -1112,7 +1123,7 @@ fun HudDesignStudio(onReturnToOneConfig: (() -> Unit)? = null) {
     val searchHits = rememberHudSearchResults(providers, searchText)
     val groupedHuds = searchHits ?: providers.groupBy { it.configId }.map { (modId, huds) -> modId to huds }
     val librarySections = groupedHuds.mapNotNull { (modId, huds) ->
-        huds.filter { it.multipleInstancesAllowed() || HudManager.getHudsOfType(it::class.java).isEmpty() }
+        huds.filter { it.multipleInstancesAllowed() || !HudManager.hasHudOfType(it::class.java) }
             .takeIf { it.isNotEmpty() }
             ?.let { HudLibrarySection(modId, modId?.let { id -> modNames[id] } ?: "Other", it) }
     }

--- a/modules/internal/src/main/kotlin/org/polyfrost/oneconfig/internal/ui/hud/screens/HudDesignStudio.kt
+++ b/modules/internal/src/main/kotlin/org/polyfrost/oneconfig/internal/ui/hud/screens/HudDesignStudio.kt
@@ -991,7 +991,7 @@ fun HudDesignStudio(onReturnToOneConfig: (() -> Unit)? = null) {
         }
     }
 
-    LaunchedEffect(Unit) {
+    LaunchedEffect(HudManager.editorOpenRevision.intValue) {
         val pending = HudManager.pendingSelection
         val pendingAdd = HudManager.pendingAdd
         HudManager.pendingSelection = null
@@ -1049,7 +1049,7 @@ fun HudDesignStudio(onReturnToOneConfig: (() -> Unit)? = null) {
         }
     }
 
-    LaunchedEffect(Unit) {
+    LaunchedEffect(HudManager.editorOpenRevision.intValue) {
         HudDesignSession.clearCommands()
         for (command in HudDesignSession.commands) {
             when (command) {

--- a/modules/internal/src/main/kotlin/org/polyfrost/oneconfig/internal/ui/keybind/KeybindCatalog.kt
+++ b/modules/internal/src/main/kotlin/org/polyfrost/oneconfig/internal/ui/keybind/KeybindCatalog.kt
@@ -46,7 +46,7 @@ object KeybindProviderRegistry {
 }
 
 fun collectAllKeybindGroups(): List<KeybindGroup> {
-    val configGroups = collectKeybindGroups(ConfigRegistry.configList.filterIsInstance<TreeConfigData>())
+    val configGroups = collectKeybindGroups(ConfigRegistry.configs.filterIsInstance<TreeConfigData>())
     return (configGroups + KeybindProviderRegistry.groups()).withUniqueModIds()
 }
 

--- a/modules/internal/src/main/kotlin/org/polyfrost/oneconfig/internal/ui/keybind/MinecraftKeybindRegistrar.kt
+++ b/modules/internal/src/main/kotlin/org/polyfrost/oneconfig/internal/ui/keybind/MinecraftKeybindRegistrar.kt
@@ -19,10 +19,22 @@ object MinecraftKeybindRegistrar {
 
     private val propByBind = WeakHashMap<OneConfigKeybind, Property<*>>()
     private val wiredProps = WeakHashMap<Property<*>, Boolean>()
+
+    /**
+     * The trees already walked, held weakly so a discarded profile's trees are not kept alive
+     *
+     * Every open reloads the registry and so re-walked every tree, which with a hundred configs is
+     * the whole property graph plus a localised title each, measured at 45 ms on the opening frame.
+     * A tree only gains properties when something registers it again on purpose, which [force] covers.
+     */
+    private val scannedTrees = WeakHashMap<Tree, Boolean>()
     private var listenerInstalled = false
 
     @JvmStatic
-    fun scan(tree: Tree) {
+    @JvmOverloads
+    fun scan(tree: Tree, force: Boolean = true) {
+        if (!force && scannedTrees.containsKey(tree)) return
+        scannedTrees[tree] = true
         installRebindListener()
         val category = "${tree.localizedTitle()} (OneConfig)"
         walk(tree, category)

--- a/modules/internal/src/main/kotlin/org/polyfrost/oneconfig/internal/ui/keybind/MinecraftKeybindRegistrar.kt
+++ b/modules/internal/src/main/kotlin/org/polyfrost/oneconfig/internal/ui/keybind/MinecraftKeybindRegistrar.kt
@@ -20,13 +20,6 @@ object MinecraftKeybindRegistrar {
     private val propByBind = WeakHashMap<OneConfigKeybind, Property<*>>()
     private val wiredProps = WeakHashMap<Property<*>, Boolean>()
 
-    /**
-     * The trees already walked, held weakly so a discarded profile's trees are not kept alive
-     *
-     * Every open reloads the registry and so re-walked every tree, which with a hundred configs is
-     * the whole property graph plus a localised title each, measured at 45 ms on the opening frame.
-     * A tree only gains properties when something registers it again on purpose, which [force] covers.
-     */
     private val scannedTrees = WeakHashMap<Tree, Boolean>()
     private var listenerInstalled = false
 

--- a/modules/internal/src/main/kotlin/org/polyfrost/oneconfig/internal/ui/screens/ConfigScreen.kt
+++ b/modules/internal/src/main/kotlin/org/polyfrost/oneconfig/internal/ui/screens/ConfigScreen.kt
@@ -358,11 +358,9 @@ private fun AccordionRow(node: SettingNode.Accordion, compact: Boolean = false) 
             .fillMaxWidth()
             .clip(shape)
             .background(theme.modCardBackground, shape)
-            .border(
-                1.dp,
-                Brush.verticalGradient(listOf(theme.borderColor, theme.borderColor.copy(0f))),
-                shape
-            )
+            .border(1.dp, remember(theme.borderColor) {
+                Brush.verticalGradient(listOf(theme.borderColor, theme.borderColor.copy(0f)))
+            }, shape)
             .drawWithCache {
                 val color = theme.textColor
                 val gradient = Brush.radialGradient(
@@ -431,7 +429,9 @@ private fun AccordionRow(node: SettingNode.Accordion, compact: Boolean = false) 
                     .fillMaxWidth()
                     .border(
                         width = 1.dp,
-                        brush = Brush.verticalGradient(listOf(theme.borderColor.copy(0f), theme.borderColor)),
+                        brush = remember(theme.borderColor) {
+                            Brush.verticalGradient(listOf(theme.borderColor.copy(0f), theme.borderColor))
+                        },
                         shape = shape
                     )
                     .padding(vertical = 12.dp)
@@ -455,11 +455,9 @@ fun SettingRow(prop: Property<*>, compact: Boolean = false) {
             .fillMaxWidth()
             .alpha(displayAlpha(display))
             .background(theme.modCardBackground, theme.modCardShape)
-            .border(
-                1.dp,
-                Brush.verticalGradient(listOf(theme.borderColor, theme.borderColor.copy(0f))),
-                theme.modCardShape
-            )
+            .border(1.dp, remember(theme.borderColor) {
+                Brush.verticalGradient(listOf(theme.borderColor, theme.borderColor.copy(0f)))
+            }, theme.modCardShape)
     ) {
         val vignetteColor = theme.textColor
         Box(

--- a/modules/internal/src/main/kotlin/org/polyfrost/oneconfig/internal/ui/screens/Keybinds.kt
+++ b/modules/internal/src/main/kotlin/org/polyfrost/oneconfig/internal/ui/screens/Keybinds.kt
@@ -112,9 +112,7 @@ fun Keybinds() {
         return
     }
 
-    val conflicts = remember(revision, providerRevision, KeybindConflicts.revision.intValue) {
-        KeybindConflicts.conflictMap()
-    }
+    val conflicts = KeybindConflicts.conflictMap()
 
     val searching = localSearchQuery.isNotBlank()
 

--- a/modules/internal/src/main/kotlin/org/polyfrost/oneconfig/internal/ui/screens/Mods.kt
+++ b/modules/internal/src/main/kotlin/org/polyfrost/oneconfig/internal/ui/screens/Mods.kt
@@ -175,8 +175,6 @@ fun ColumnScope.ModsGrid(category: ModCategory) {
             items(
                 entries,
                 key = { it.key },
-                // cards are all the same shape, so the grid can reuse one scrolling out instead of
-                // building a fresh subcomposition and node tree for every one scrolling in
                 contentType = { if (it is ModGridEntry.Header) HEADER_CONTENT_TYPE else CARD_CONTENT_TYPE },
                 span = { if (it is ModGridEntry.Header) GridItemSpan(maxLineSpan) else GridItemSpan(1) },
             ) { entry ->
@@ -279,13 +277,11 @@ private fun commitDrop(entries: List<ModGridEntry>, index: Int) {
     )
 }
 
-/** headers and cards lay out differently, so each may only be reused for its own kind */
 private const val HEADER_CONTENT_TYPE = "header"
 private const val CARD_CONTENT_TYPE = "card"
 
 private val ModCardFooterHeight = 36.dp
 
-/** how far the accent glow reaches up from the bottom of a card */
 private val ModCardGlowHeight = 50.dp
 
 private val FavoriteStarColor = Color(0xFFFFD700)
@@ -317,8 +313,6 @@ fun ModCard(mod: ConfigData, modifier: Modifier = Modifier) {
                 contentAlignment = Alignment.Center
             ) {
                 val preview = mod.preview
-                // canRenderIcon stats the filesystem, and this runs for every card on every
-                // recomposition, so decide it once per icon
                 val icon = remember(mod.icon) { mod.icon?.takeIf(::canRenderIcon) }
                 if (preview != null) {
                     preview(Modifier.fillMaxSize().padding(horizontal = 12.dp, vertical = 8.dp))
@@ -355,8 +349,6 @@ fun ModCard(mod: ConfigData, modifier: Modifier = Modifier) {
         }
 
         if (LocalTheme.current.shadowEnabled) {
-            // one box, not two: both are decoration over the whole card, and a box each cost every
-            // card an extra layout node and an extra draw node
             val vignetteColor = theme.textColor
             Box(
                 Modifier.fillMaxSize().drawWithCache {
@@ -392,8 +384,6 @@ fun ModCard(mod: ConfigData, modifier: Modifier = Modifier) {
 
         FavoriteStar(
             mod = mod,
-            // the source rather than its state: reading the state here would recompose the whole
-            // card on hover, both gradients and labels and the icon, instead of just the star
             cardInteractions = interactionSource,
             modifier = Modifier.align(Alignment.TopEnd),
         )

--- a/modules/internal/src/main/kotlin/org/polyfrost/oneconfig/internal/ui/screens/Mods.kt
+++ b/modules/internal/src/main/kotlin/org/polyfrost/oneconfig/internal/ui/screens/Mods.kt
@@ -24,6 +24,7 @@ import androidx.compose.foundation.lazy.grid.GridCells
 import androidx.compose.foundation.lazy.grid.GridItemSpan
 import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
 import androidx.compose.foundation.lazy.grid.items
+import androidx.compose.foundation.interaction.InteractionSource
 import androidx.compose.foundation.interaction.collectIsHoveredAsState
 import androidx.compose.foundation.rememberScrollbarAdapter
 import androidx.compose.runtime.Composable
@@ -38,6 +39,8 @@ import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.draw.drawWithCache
 import androidx.compose.ui.draw.rotate
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.geometry.Size
 import androidx.compose.ui.geometry.center
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
@@ -172,6 +175,9 @@ fun ColumnScope.ModsGrid(category: ModCategory) {
             items(
                 entries,
                 key = { it.key },
+                // cards are all the same shape, so the grid can reuse one scrolling out instead of
+                // building a fresh subcomposition and node tree for every one scrolling in
+                contentType = { if (it is ModGridEntry.Header) HEADER_CONTENT_TYPE else CARD_CONTENT_TYPE },
                 span = { if (it is ModGridEntry.Header) GridItemSpan(maxLineSpan) else GridItemSpan(1) },
             ) { entry ->
                 when (entry) {
@@ -223,7 +229,7 @@ private fun ModTypeHeader(entry: ModGridEntry.Header, modifier: Modifier = Modif
         horizontalArrangement = Arrangement.spacedBy(10.dp),
     ) {
         Rule(Modifier.weight(1f))
-        entry.type.icon?.takeIf(::canRenderIcon)?.let { icon ->
+        remember(entry.type.icon) { entry.type.icon?.takeIf(::canRenderIcon) }?.let { icon ->
             Icon(icon, color = theme.textColorSecondary, modifier = Modifier.size(14.dp))
         }
         Text(
@@ -273,7 +279,14 @@ private fun commitDrop(entries: List<ModGridEntry>, index: Int) {
     )
 }
 
+/** headers and cards lay out differently, so each may only be reused for its own kind */
+private const val HEADER_CONTENT_TYPE = "header"
+private const val CARD_CONTENT_TYPE = "card"
+
 private val ModCardFooterHeight = 36.dp
+
+/** how far the accent glow reaches up from the bottom of a card */
+private val ModCardGlowHeight = 50.dp
 
 private val FavoriteStarColor = Color(0xFFFFD700)
 
@@ -285,11 +298,9 @@ fun ModCard(mod: ConfigData, modifier: Modifier = Modifier) {
     Box(
         modifier = modifier.fillMaxWidth().height(140.dp)
             .background(theme.modCardBackground, theme.modCardShape)
-            .border(
-                1.dp, Brush.verticalGradient(
-                    listOf(theme.borderColor, theme.borderColor.copy(0f))
-                ), theme.modCardShape
-            )
+            .border(1.dp, remember(theme.borderColor) {
+                Brush.verticalGradient(listOf(theme.borderColor, theme.borderColor.copy(0f)))
+            }, theme.modCardShape)
             .onClick(interactionSource) {
                 val onOpen = mod.onOpen
                 when {
@@ -306,14 +317,16 @@ fun ModCard(mod: ConfigData, modifier: Modifier = Modifier) {
                 contentAlignment = Alignment.Center
             ) {
                 val preview = mod.preview
-                val icon = mod.icon?.takeIf(::canRenderIcon)
+                // canRenderIcon stats the filesystem, and this runs for every card on every
+                // recomposition, so decide it once per icon
+                val icon = remember(mod.icon) { mod.icon?.takeIf(::canRenderIcon) }
                 if (preview != null) {
                     preview(Modifier.fillMaxSize().padding(horizontal = 12.dp, vertical = 8.dp))
                 } else if (icon != null) {
                     Icon(icon, color = theme.textColor, modifier = Modifier.size(48.dp))
                 } else {
                     Text(
-                        mod.title.asRenderText(),
+                        remember(mod.title) { mod.title.asRenderText() },
                         color = theme.textColor,
                         fontSize = 16.sp,
                         lineHeight = 18.sp,
@@ -342,10 +355,12 @@ fun ModCard(mod: ConfigData, modifier: Modifier = Modifier) {
         }
 
         if (LocalTheme.current.shadowEnabled) {
+            // one box, not two: both are decoration over the whole card, and a box each cost every
+            // card an extra layout node and an extra draw node
             val vignetteColor = theme.textColor
             Box(
                 Modifier.fillMaxSize().drawWithCache {
-                    val gradient = Brush.radialGradient(
+                    val vignette = Brush.radialGradient(
                         colors = listOf(
                             vignetteColor.copy(alpha = 0f),
                             vignetteColor.copy(alpha = 0.04f),
@@ -354,36 +369,48 @@ fun ModCard(mod: ConfigData, modifier: Modifier = Modifier) {
                         center = size.center,
                         radius = size.minDimension * 0.9f
                     )
-                    onDrawBehind { drawRect(gradient) }
-                }
-            )
-            val gradient = Brush.verticalGradient(
-                0f to Accent.copy(0f),
-                0.4f to Accent.copy(0.2f),
-                1f to Accent.copy(0.4f),
-            )
-
-            Box(
-                Modifier.align(Alignment.BottomCenter).height(50.dp).fillMaxWidth().drawWithCache {
-                    onDrawBehind { drawRect(gradient) }
+                    val glowHeight = ModCardGlowHeight.toPx().coerceAtMost(size.height)
+                    val glowTop = size.height - glowHeight
+                    val glow = Brush.verticalGradient(
+                        0f to Accent.copy(0f),
+                        0.4f to Accent.copy(0.2f),
+                        1f to Accent.copy(0.4f),
+                        startY = glowTop,
+                        endY = size.height,
+                    )
+                    onDrawBehind {
+                        drawRect(vignette)
+                        drawRect(
+                            glow,
+                            topLeft = Offset(0f, glowTop),
+                            size = Size(size.width, glowHeight),
+                        )
+                    }
                 }
             )
         }
 
         FavoriteStar(
             mod = mod,
-            cardHovered = interactionSource.collectIsHoveredAsState().value,
+            // the source rather than its state: reading the state here would recompose the whole
+            // card on hover, both gradients and labels and the icon, instead of just the star
+            cardInteractions = interactionSource,
             modifier = Modifier.align(Alignment.TopEnd),
         )
     }
 }
 
 @Composable
-private fun FavoriteStar(mod: ConfigData, cardHovered: Boolean, modifier: Modifier = Modifier) {
+private fun FavoriteStar(
+    mod: ConfigData,
+    cardInteractions: InteractionSource,
+    modifier: Modifier = Modifier,
+) {
     val theme = LocalTheme.current
     val favorite = ModFavorites.isFavorite(mod.id)
     val interactionSource = rememberInteractionSource()
     val hovered by interactionSource.collectIsHoveredAsState()
+    val cardHovered by cardInteractions.collectIsHoveredAsState()
     val alpha by animateFloatAsState(
         when {
             favorite || hovered -> 1f

--- a/modules/internal/src/main/kotlin/org/polyfrost/oneconfig/internal/ui/screens/SearchResultsScreen.kt
+++ b/modules/internal/src/main/kotlin/org/polyfrost/oneconfig/internal/ui/screens/SearchResultsScreen.kt
@@ -37,7 +37,6 @@ private const val MOD_GRID_COLUMNS = 4
 private val MOD_GRID_GAP = 19.dp
 private val LIST_GAP = 8.dp
 
-/** The list already spaces its items, so a mod row only adds the difference up to the grid gap */
 private val MOD_ROW_EXTRA_GAP = MOD_GRID_GAP - LIST_GAP
 
 @Composable
@@ -100,16 +99,12 @@ fun SearchResultsScreen(query: String) {
                         modifier = Modifier.padding(bottom = 4.dp)
                     )
                 }
-                // one item per row, not one item holding every row: the whole grid in a single item
-                // composes every match on the keystroke that produced it, so the list stopped being lazy
                 items(modRows.size, key = { "mods-row:$it" }) { index ->
                     BoxWithConstraints(
                         Modifier
                             .fillMaxWidth()
                             .padding(bottom = if (index == modRows.lastIndex) 0.dp else MOD_ROW_EXTRA_GAP)
                     ) {
-                        // four cells and three gaps come to exactly maxWidth and each rounds up on its
-                        // own, so divide in pixels and leave the remainder as slack, as the grid does
                         val cellWidth = with(LocalDensity.current) {
                             val gap = MOD_GRID_GAP.roundToPx()
                             ((maxWidth.roundToPx() - gap * (MOD_GRID_COLUMNS - 1)) / MOD_GRID_COLUMNS).toDp()

--- a/modules/internal/src/main/kotlin/org/polyfrost/oneconfig/internal/ui/screens/SearchResultsScreen.kt
+++ b/modules/internal/src/main/kotlin/org/polyfrost/oneconfig/internal/ui/screens/SearchResultsScreen.kt
@@ -4,7 +4,7 @@ import androidx.compose.foundation.VerticalScrollbar
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.BoxWithConstraints
-import androidx.compose.foundation.layout.FlowRow
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -15,6 +15,7 @@ import androidx.compose.foundation.rememberScrollbarAdapter
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
@@ -34,6 +35,10 @@ import org.polyfrost.oneconfig.internal.ui.themes.LocalTheme
 
 private const val MOD_GRID_COLUMNS = 4
 private val MOD_GRID_GAP = 19.dp
+private val LIST_GAP = 8.dp
+
+/** The list already spaces its items, so a mod row only adds the difference up to the grid gap */
+private val MOD_ROW_EXTRA_GAP = MOD_GRID_GAP - LIST_GAP
 
 @Composable
 fun SearchResultsScreen(query: String) {
@@ -65,6 +70,8 @@ fun SearchResultsScreen(query: String) {
         byGroup
     }
 
+    val modRows = remember(matchingMods) { matchingMods.chunked(MOD_GRID_COLUMNS) }
+
     val listState = rememberRestorableLazyListState("global-search", query, searchedQuery)
 
     if (matchingMods.isEmpty() && groupedOptions.isEmpty()) {
@@ -81,7 +88,7 @@ fun SearchResultsScreen(query: String) {
         LazyColumn(
             state = listState,
             modifier = Modifier.fillMaxSize().padding(end = 16.dp),
-            verticalArrangement = Arrangement.spacedBy(8.dp),
+            verticalArrangement = Arrangement.spacedBy(LIST_GAP),
         ) {
             if (matchingMods.isNotEmpty()) {
                 item(key = "header:mods") {
@@ -93,24 +100,23 @@ fun SearchResultsScreen(query: String) {
                         modifier = Modifier.padding(bottom = 4.dp)
                     )
                 }
-                item(key = "mods-grid") {
-                    BoxWithConstraints(Modifier.fillMaxWidth()) {
-                        val cellWidth = (maxWidth - MOD_GRID_GAP * (MOD_GRID_COLUMNS - 1)) / MOD_GRID_COLUMNS
-                        FlowRow(
-                            horizontalArrangement = Arrangement.spacedBy(MOD_GRID_GAP),
-                            verticalArrangement = Arrangement.spacedBy(MOD_GRID_GAP),
-                            modifier = Modifier.fillMaxWidth(),
-                            maxItemsInEachRow = MOD_GRID_COLUMNS,
-                        ) {
-                            matchingMods.forEach { mod ->
-                                Box(Modifier.width(cellWidth)) {
-                                    ModCard(mod)
-                                }
-                            }
-                            val remainder =
-                                (MOD_GRID_COLUMNS - matchingMods.size % MOD_GRID_COLUMNS) % MOD_GRID_COLUMNS
-                            repeat(remainder) {
-                                Box(Modifier.width(cellWidth))
+                // one item per row, not one item holding every row: the whole grid in a single item
+                // composes every match on the keystroke that produced it, so the list stopped being lazy
+                items(modRows.size, key = { "mods-row:$it" }) { index ->
+                    BoxWithConstraints(
+                        Modifier
+                            .fillMaxWidth()
+                            .padding(bottom = if (index == modRows.lastIndex) 0.dp else MOD_ROW_EXTRA_GAP)
+                    ) {
+                        // four cells and three gaps come to exactly maxWidth and each rounds up on its
+                        // own, so divide in pixels and leave the remainder as slack, as the grid does
+                        val cellWidth = with(LocalDensity.current) {
+                            val gap = MOD_GRID_GAP.roundToPx()
+                            ((maxWidth.roundToPx() - gap * (MOD_GRID_COLUMNS - 1)) / MOD_GRID_COLUMNS).toDp()
+                        }
+                        Row(horizontalArrangement = Arrangement.spacedBy(MOD_GRID_GAP)) {
+                            modRows[index].forEach { mod ->
+                                Box(Modifier.width(cellWidth)) { ModCard(mod) }
                             }
                         }
                     }

--- a/modules/internal/src/main/kotlin/org/polyfrost/oneconfig/internal/ui/shell/Data.kt
+++ b/modules/internal/src/main/kotlin/org/polyfrost/oneconfig/internal/ui/shell/Data.kt
@@ -136,6 +136,8 @@ object LocalNavController {
 
         private var currentEntry = Entry(ModsGraph)
 
+        val currentRoute: Any get() = currentEntry.route
+
         fun reset() {
             backStack.clear()
             forwardStack.clear()

--- a/modules/internal/src/main/kotlin/org/polyfrost/oneconfig/internal/ui/shell/Data.kt
+++ b/modules/internal/src/main/kotlin/org/polyfrost/oneconfig/internal/ui/shell/Data.kt
@@ -70,13 +70,6 @@ object ShellState {
     /** Where each scrollable page was left keyed by page key see [rememberRestorableLazyListState] */
     val scrollAnchors = mutableMapOf<String, ScrollAnchor>()
 
-    /**
-     * The live grid states, by the same key their scroll position is remembered under
-     *
-     * A warm-up drives these so a list can be scrolled through before anyone looks at it, which is
-     * the only way to reach the work that only happens when an item first comes into view. Written
-     * and read on the render thread, like everything else here.
-     */
     val gridStates = mutableMapOf<String, LazyGridState>()
 
     /** Last selected settings tab per page key restored when a page is reopened or navigated back to */

--- a/modules/internal/src/main/kotlin/org/polyfrost/oneconfig/internal/ui/shell/Data.kt
+++ b/modules/internal/src/main/kotlin/org/polyfrost/oneconfig/internal/ui/shell/Data.kt
@@ -1,5 +1,6 @@
 package org.polyfrost.oneconfig.internal.ui.shell
 
+import androidx.compose.foundation.lazy.grid.LazyGridState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateMapOf
 import androidx.compose.runtime.mutableStateOf
@@ -68,6 +69,15 @@ object ShellState {
 
     /** Where each scrollable page was left keyed by page key see [rememberRestorableLazyListState] */
     val scrollAnchors = mutableMapOf<String, ScrollAnchor>()
+
+    /**
+     * The live grid states, by the same key their scroll position is remembered under
+     *
+     * A warm-up drives these so a list can be scrolled through before anyone looks at it, which is
+     * the only way to reach the work that only happens when an item first comes into view. Written
+     * and read on the render thread, like everything else here.
+     */
+    val gridStates = mutableMapOf<String, LazyGridState>()
 
     /** Last selected settings tab per page key restored when a page is reopened or navigated back to */
     val selectedCategories = mutableStateMapOf<String, String>()

--- a/modules/internal/src/main/kotlin/org/polyfrost/oneconfig/internal/ui/shell/ScrollMemory.kt
+++ b/modules/internal/src/main/kotlin/org/polyfrost/oneconfig/internal/ui/shell/ScrollMemory.kt
@@ -5,6 +5,7 @@ import androidx.compose.foundation.lazy.grid.LazyGridState
 import androidx.compose.foundation.lazy.grid.rememberLazyGridState
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
@@ -65,6 +66,10 @@ private class LastKey(var value: Any?)
 fun rememberRestorableLazyGridState(key: String): LazyGridState {
     val anchor = remember(key) { ShellState.scrollAnchors[key] }
     val state = rememberLazyGridState(anchor?.index ?: 0, anchor?.offset ?: 0)
+    DisposableEffect(state, key) {
+        ShellState.gridStates[key] = state
+        onDispose { if (ShellState.gridStates[key] === state) ShellState.gridStates.remove(key) }
+    }
     LaunchedEffect(state, key) {
         snapshotFlow { ScrollAnchor(state.firstVisibleItemIndex, state.firstVisibleItemScrollOffset) }
             .collect { ShellState.scrollAnchors[key] = it }

--- a/modules/internal/src/main/kotlin/org/polyfrost/oneconfig/internal/ui/shell/Shell.kt
+++ b/modules/internal/src/main/kotlin/org/polyfrost/oneconfig/internal/ui/shell/Shell.kt
@@ -143,8 +143,6 @@ fun Shell(
 
     val glowCache = remember { GlowCache() }
 
-    // read here rather than in the draw: a read inside a draw scope makes this layer depend on it,
-    // and the shell background is the one thing drawn on every frame of every page
     val glowAlpha = (ShellState.glowOpacity / 100f).coerceIn(0f, 1f)
     val glowPaint = remember(Accent) {
         Paint().apply {

--- a/modules/internal/src/main/kotlin/org/polyfrost/oneconfig/internal/ui/shell/Shell.kt
+++ b/modules/internal/src/main/kotlin/org/polyfrost/oneconfig/internal/ui/shell/Shell.kt
@@ -142,6 +142,10 @@ fun Shell(
     }
 
     val glowCache = remember { GlowCache() }
+
+    // read here rather than in the draw: a read inside a draw scope makes this layer depend on it,
+    // and the shell background is the one thing drawn on every frame of every page
+    val glowAlpha = (ShellState.glowOpacity / 100f).coerceIn(0f, 1f)
     val glowPaint = remember(Accent) {
         Paint().apply {
             colorFilter = ColorFilter.makeBlend(Accent.copy(alpha = 1f).toArgb(), SkBlendMode.SRC_IN)
@@ -163,7 +167,7 @@ fun Shell(
                 val glow = glowCache.imageFor(
                     ceil(size.width).toInt(),
                     ceil(size.height).toInt(),
-                    (ShellState.glowOpacity / 100f).coerceIn(0f, 1f),
+                    glowAlpha,
                 )
                 if (glow != null) {
                     drawIntoCanvas {

--- a/modules/internal/src/main/kotlin/org/polyfrost/oneconfig/internal/ui/themes/Provider.kt
+++ b/modules/internal/src/main/kotlin/org/polyfrost/oneconfig/internal/ui/themes/Provider.kt
@@ -19,7 +19,6 @@ import androidx.compose.ui.platform.LocalWindowInfo
 import androidx.compose.ui.unit.Density
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
-import kotlinx.coroutines.delay
 import androidx.compose.ui.graphics.toArgb
 import org.polyfrost.compose.render.PolyColor
 import org.polyfrost.oneconfig.api.notifications.v1.NotificationTheme
@@ -34,9 +33,15 @@ import kotlin.math.round
 
 private var _accent by mutableStateOf(Color(ThemeConfig.accentColor.argb))
 
+// only a chroma accent changes on its own, so only that one is worth waiting on a frame
+private var _chroma by mutableStateOf(ThemeConfig.accentColor.chroma)
+
 val Accent: Color get() = _accent
 
-fun updateAccent() { _accent = Color(ThemeConfig.accentColor.argb) }
+fun updateAccent() {
+    _accent = Color(ThemeConfig.accentColor.argb)
+    _chroma = ThemeConfig.accentColor.chroma
+}
 
 val LocalTheme = compositionLocalOf<UITheme> { error("A UI theme is required but was not provided") }
 
@@ -109,16 +114,14 @@ fun Theme(
     designHeight: Dp = DESIGN_HEIGHT_DP.dp,
     content: @Composable () -> Unit,
 ) {
-    _accent = Color(ThemeConfig.accentColor.argb)
+    updateAccent()
 
-    LaunchedEffect(Unit) {
-        while (true) {
-            if (ThemeConfig.accentColor.chroma) {
-                withFrameNanos { }
-                updateAccent()
-            } else {
-                delay(200)
-            }
+    // waiting on the clock unconditionally leaves an awaiter on it forever, and Compose reads that
+    // as pending work, so every frame came back dirty and redrew the whole screen
+    LaunchedEffect(_chroma) {
+        while (_chroma) {
+            withFrameNanos { }
+            updateAccent()
         }
     }
 

--- a/modules/internal/src/main/kotlin/org/polyfrost/oneconfig/internal/ui/themes/Provider.kt
+++ b/modules/internal/src/main/kotlin/org/polyfrost/oneconfig/internal/ui/themes/Provider.kt
@@ -33,7 +33,6 @@ import kotlin.math.round
 
 private var _accent by mutableStateOf(Color(ThemeConfig.accentColor.argb))
 
-// only a chroma accent changes on its own, so only that one is worth waiting on a frame
 private var _chroma by mutableStateOf(ThemeConfig.accentColor.chroma)
 
 val Accent: Color get() = _accent
@@ -116,8 +115,6 @@ fun Theme(
 ) {
     updateAccent()
 
-    // waiting on the clock unconditionally leaves an awaiter on it forever, and Compose reads that
-    // as pending work, so every frame came back dirty and redrew the whole screen
     LaunchedEffect(_chroma) {
         while (_chroma) {
             withFrameNanos { }

--- a/modules/poly-compose/src/main/kotlin/org/polyfrost/compose/runtime/PolyComposeHost.kt
+++ b/modules/poly-compose/src/main/kotlin/org/polyfrost/compose/runtime/PolyComposeHost.kt
@@ -9,7 +9,9 @@ import kotlinx.coroutines.CoroutineStart
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 
-object PolyComposeHost {
+// a composition only does work on a frame, so one attached to a clock nobody ticks costs nothing.
+// that is what lets a composition stay alive while nothing is looking at it
+class PolyComposeClock {
     private val clock = BroadcastFrameClock()
     private val scope = CoroutineScope(Dispatchers.Unconfined + clock)
 
@@ -21,6 +23,30 @@ object PolyComposeHost {
 
     internal val recomposer: CompositionContext get() = recomposerImpl
 
+    /**
+     * runs a frame and reports whether the content may have changed
+     *
+     * a second clock ticked in the same frame must pass false: sendApplyNotifications is global,
+     * and firing it again mid frame hands new state to trees already composed against the old.
+     */
+    fun frame(nanos: Long = System.nanoTime(), notify: Boolean = true): Boolean {
+        if (notify) Snapshot.sendApplyNotifications()
+        val appliedBefore = recomposerImpl.changeCount
+        clock.sendFrame(nanos)
+        return recomposerImpl.changeCount != appliedBefore || recomposerImpl.hasPendingWork
+    }
+}
+
+object PolyComposeHost {
+    /** Drives the HUDs actually on screen, ticked every frame */
+    val huds = PolyComposeClock()
+
+    // drives HUD previews, ticked only while a UI showing them draws. they are expensive to build
+    // so they are kept for the process and simply left alone the rest of the time
+    val previews = PolyComposeClock()
+
+    internal val recomposer: CompositionContext get() = huds.recomposer
+
     fun frame(nanos: Long = System.nanoTime()) {
         frameWithReport(nanos)
     }
@@ -28,10 +54,5 @@ object PolyComposeHost {
     /**
      * Runs a frame like [frame] and reports whether composition content may have changed
      */
-    fun frameWithReport(nanos: Long = System.nanoTime()): Boolean {
-        Snapshot.sendApplyNotifications()
-        val appliedBefore = recomposerImpl.changeCount
-        clock.sendFrame(nanos)
-        return recomposerImpl.changeCount != appliedBefore || recomposerImpl.hasPendingWork
-    }
+    fun frameWithReport(nanos: Long = System.nanoTime()): Boolean = huds.frame(nanos)
 }

--- a/modules/poly-compose/src/main/kotlin/org/polyfrost/compose/runtime/PolyComposeHost.kt
+++ b/modules/poly-compose/src/main/kotlin/org/polyfrost/compose/runtime/PolyComposeHost.kt
@@ -9,8 +9,6 @@ import kotlinx.coroutines.CoroutineStart
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 
-// a composition only does work on a frame, so one attached to a clock nobody ticks costs nothing.
-// that is what lets a composition stay alive while nothing is looking at it
 class PolyComposeClock {
     private val clock = BroadcastFrameClock()
     private val scope = CoroutineScope(Dispatchers.Unconfined + clock)
@@ -23,12 +21,6 @@ class PolyComposeClock {
 
     internal val recomposer: CompositionContext get() = recomposerImpl
 
-    /**
-     * runs a frame and reports whether the content may have changed
-     *
-     * a second clock ticked in the same frame must pass false: sendApplyNotifications is global,
-     * and firing it again mid frame hands new state to trees already composed against the old.
-     */
     fun frame(nanos: Long = System.nanoTime(), notify: Boolean = true): Boolean {
         if (notify) Snapshot.sendApplyNotifications()
         val appliedBefore = recomposerImpl.changeCount
@@ -37,17 +29,13 @@ class PolyComposeClock {
         return appliedChange || recomposerImpl.hasPendingWork
     }
 
-    /** whether the last [frame] actually changed the content, rather than only leaving work pending */
     var appliedChange = false
         private set
 }
 
 object PolyComposeHost {
-    /** Drives the HUDs actually on screen, ticked every frame */
     val huds = PolyComposeClock()
 
-    // drives HUD previews, ticked only while a UI showing them draws. they are expensive to build
-    // so they are kept for the process and simply left alone the rest of the time
     val previews = PolyComposeClock()
 
     internal val recomposer: CompositionContext get() = huds.recomposer

--- a/modules/poly-compose/src/main/kotlin/org/polyfrost/compose/runtime/PolyComposeHost.kt
+++ b/modules/poly-compose/src/main/kotlin/org/polyfrost/compose/runtime/PolyComposeHost.kt
@@ -33,8 +33,13 @@ class PolyComposeClock {
         if (notify) Snapshot.sendApplyNotifications()
         val appliedBefore = recomposerImpl.changeCount
         clock.sendFrame(nanos)
-        return recomposerImpl.changeCount != appliedBefore || recomposerImpl.hasPendingWork
+        appliedChange = recomposerImpl.changeCount != appliedBefore
+        return appliedChange || recomposerImpl.hasPendingWork
     }
+
+    /** whether the last [frame] actually changed the content, rather than only leaving work pending */
+    var appliedChange = false
+        private set
 }
 
 object PolyComposeHost {

--- a/modules/poly-compose/src/main/kotlin/org/polyfrost/compose/runtime/PolyComposeRuntime.kt
+++ b/modules/poly-compose/src/main/kotlin/org/polyfrost/compose/runtime/PolyComposeRuntime.kt
@@ -4,15 +4,15 @@ import androidx.compose.runtime.*
 import org.polyfrost.compose.layout.PolyLayoutEngine
 import org.polyfrost.compose.node.RootNode
 
-class PolyComposeRuntime {
+class PolyComposeRuntime(private val host: PolyComposeClock = PolyComposeHost.huds) {
     val root = RootNode()
 
-    private val composition = Composition(PolyApplier(root), PolyComposeHost.recomposer)
+    private val composition = Composition(PolyApplier(root), host.recomposer)
 
     fun setContent(content: @Composable () -> Unit) = composition.setContent(content)
 
     fun frame(parentWidth: Float, parentHeight: Float, nanos: Long = System.nanoTime()) {
-        PolyComposeHost.frame(nanos)
+        host.frame(nanos)
         layout(parentWidth, parentHeight)
     }
 

--- a/modules/root.gradle.kts
+++ b/modules/root.gradle.kts
@@ -93,9 +93,6 @@ subprojects {
 
     base.archivesName = name
 
-    // Kotlin mangles every internal member's JVM name with the module name, and 2.4 changed that
-    // default from the archives name to the maven coordinates, which renamed a published ABI:
-    // PolyPlus stopped linking against ThemeRegistry.getRegistry$internal the moment it moved
     val kotlinModuleName = project.name
     tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile>().configureEach {
         compilerOptions.moduleName = kotlinModuleName

--- a/modules/root.gradle.kts
+++ b/modules/root.gradle.kts
@@ -93,6 +93,14 @@ subprojects {
 
     base.archivesName = name
 
+    // Kotlin mangles every internal member's JVM name with the module name, and 2.4 changed that
+    // default from the archives name to the maven coordinates, which renamed a published ABI:
+    // PolyPlus stopped linking against ThemeRegistry.getRegistry$internal the moment it moved
+    val kotlinModuleName = project.name
+    tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile>().configureEach {
+        compilerOptions.moduleName = kotlinModuleName
+    }
+
     configure<JavaPluginExtension> {
         if("dependencies" !in project.path) {
             withJavadocJar()

--- a/modules/utils/src/main/java/org/polyfrost/oneconfig/utils/v1/Multithreading.java
+++ b/modules/utils/src/main/java/org/polyfrost/oneconfig/utils/v1/Multithreading.java
@@ -26,9 +26,6 @@
 
 package org.polyfrost.oneconfig.utils.v1;
 
-
-import org.jetbrains.annotations.NotNull;
-
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
@@ -46,9 +43,6 @@ import java.util.concurrent.atomic.AtomicInteger;
  * </p>
  */
 public final class Multithreading {
-    private static ExecutorService executorService = null; /* by lazy { Executors.newCachedThreadPool(ThreadFactoryBuilder().setNameFormat("OneConfig-%d").build()) } */
-    private static ScheduledExecutorService runnableExecutor = null;
-
     private Multithreading() {
     }
 
@@ -101,32 +95,34 @@ public final class Multithreading {
     }
 
     public static ExecutorService getExecutor() {
-        if (executorService == null) executorService = Executors.newCachedThreadPool(new ThreadFactory() {
-            private final AtomicInteger ai = new AtomicInteger();
-
-            @Override
-            public Thread newThread(@NotNull Runnable r) {
-                Thread t = Executors.defaultThreadFactory().newThread(r);
-                t.setName("OneConfig-" + ai.getAndIncrement());
-                t.setDaemon(true);
-                return t;
-            }
-        });
-        return executorService;
+        return SharedPool.INSTANCE;
     }
 
     public static ScheduledExecutorService getScheduledExecutor() {
-        if (runnableExecutor == null) runnableExecutor = Executors.newScheduledThreadPool(Runtime.getRuntime().availableProcessors() - 2, new ThreadFactory() {
-            private final AtomicInteger ai = new AtomicInteger();
+        return ScheduledPool.INSTANCE;
+    }
 
-            @Override
-            public Thread newThread(@NotNull Runnable r) {
-                Thread t = Executors.defaultThreadFactory().newThread(r);
-                t.setName("OneConfig-Scheduled-" + ai.getAndIncrement());
-                t.setDaemon(true);
-                return t;
-            }
-        });
-        return runnableExecutor;
+    // a holder each, so the pool is built once on first use without a lock. the null checks these
+    // replaced were not thread safe, and two callers racing them each built a pool and leaked one
+    private static final class SharedPool {
+        static final ExecutorService INSTANCE = Executors.newCachedThreadPool(threadFactory("OneConfig-"));
+    }
+
+    private static final class ScheduledPool {
+        // leaves the game a couple of cores, but never asks for a negative pool:
+        // availableProcessors() is 1 on a single core machine and the constructor rejects that
+        static final ScheduledExecutorService INSTANCE = Executors.newScheduledThreadPool(
+                Math.max(1, Runtime.getRuntime().availableProcessors() - 2),
+                threadFactory("OneConfig-Scheduled-"));
+    }
+
+    private static ThreadFactory threadFactory(String prefix) {
+        AtomicInteger counter = new AtomicInteger();
+        return r -> {
+            Thread t = Executors.defaultThreadFactory().newThread(r);
+            t.setName(prefix + counter.getAndIncrement());
+            t.setDaemon(true);
+            return t;
+        };
     }
 }

--- a/modules/utils/src/main/java/org/polyfrost/oneconfig/utils/v1/Multithreading.java
+++ b/modules/utils/src/main/java/org/polyfrost/oneconfig/utils/v1/Multithreading.java
@@ -102,15 +102,11 @@ public final class Multithreading {
         return ScheduledPool.INSTANCE;
     }
 
-    // a holder each, so the pool is built once on first use without a lock. the null checks these
-    // replaced were not thread safe, and two callers racing them each built a pool and leaked one
     private static final class SharedPool {
         static final ExecutorService INSTANCE = Executors.newCachedThreadPool(threadFactory("OneConfig-"));
     }
 
     private static final class ScheduledPool {
-        // leaves the game a couple of cores, but never asks for a negative pool:
-        // availableProcessors() is 1 on a single core machine and the constructor rejects that
         static final ScheduledExecutorService INSTANCE = Executors.newScheduledThreadPool(
                 Math.max(1, Runtime.getRuntime().availableProcessors() - 2),
                 threadFactory("OneConfig-Scheduled-"));

--- a/modules/utils/src/main/kotlin/org/polyfrost/oneconfig/api/platform/v1/ModInfo.kt
+++ b/modules/utils/src/main/kotlin/org/polyfrost/oneconfig/api/platform/v1/ModInfo.kt
@@ -45,8 +45,6 @@ data class ModInfo @JvmOverloads constructor(
     }
 
     companion object {
-        // building this walks the loader's whole mod list, and the settings list asks once per
-        // config as it composes. empty means the game is still loading, so that answer is not kept
         @Volatile
         private var cached: Set<ModInfo>? = null
 

--- a/modules/utils/src/main/kotlin/org/polyfrost/oneconfig/api/platform/v1/ModInfo.kt
+++ b/modules/utils/src/main/kotlin/org/polyfrost/oneconfig/api/platform/v1/ModInfo.kt
@@ -45,8 +45,14 @@ data class ModInfo @JvmOverloads constructor(
     }
 
     companion object {
+        // building this walks the loader's whole mod list, and the settings list asks once per
+        // config as it composes. empty means the game is still loading, so that answer is not kept
+        @Volatile
+        private var cached: Set<ModInfo>? = null
+
         @get:JvmStatic
-        val loadedMods: Set<ModInfo> get() = Platform.compatibility().mods
+        val loadedMods: Set<ModInfo>
+            get() = cached ?: Platform.compatibility().mods.also { if (it.isNotEmpty()) cached = it }
     }
 }
 


### PR DESCRIPTION
<details>
<summary><b>28 performance fixes</b> (click to expand, ranked worst first)</summary>

1. **HUD previews redrew the whole interface every frame.** A preview reads live values like a clock, and reading them in the draw scope made the layer depend on them, so one ticking HUD redrew everything.
2. **Opening the HUD editor spent 2272 ms** resolving every one of its own icons inline the first time. Warmed ahead of time it is **52 ms, about 43x faster**.
3. **The warm-up built the UI at 854x480 against 30 of 138 configs**, so it laid out the wrong size against a fraction of the data and the first real open still cost 197 ms redoing it.
4. **Reopening the UI cost ~72 ms, now ~9 ms.** The scene and composition survive a close, so reopening reuses the tree rather than building it again.
5. **The warm-up landed as a single 1332 ms frame** as the world appeared. It runs one frame at a time now, on the title screen.
6. **Every icon draw built and destroyed a native image.** The mod list draws over a hundred a frame, and the finalisers those queued held the render thread for **320 ms**.
7. **Icons were re-parsed every time a card scrolled back into view.** Caching the raster took the mean scroll frame from **17.2 ms to 5.1 ms** and the worst second from **64.7 ms to 19.3 ms**.
8. **An icon is only rasterised the first time its card is drawn**, so no prefetch reached it. The warm-up drags the grid top to bottom and back, at the size a real scroll asks for.
9. **Every open re-registered every config tree**, walking the whole property graph and localising a title per tree, with nothing changed between opens. **45 ms, every time.**
10. **The first colour picker or keybind row cost 40-50 ms to load its class**, because the loader searches every jar and the ASM transformers rescan interfaces. Done on a thread now.
11. **Focusing the search field cost 40 ms.** Compose lays out a paragraph just to report the field's rectangle, which drags in the whole Skia text stack. The warm-up does it offscreen.
12. **The loader's mod list was rebuilt once per config per frame**, hundreds of times a frame, measured at **50 ms** on the frame the settings list laid itself out.
13. **A classpath icon miss walks every jar the game loaded**, 139 here including a 78 MB compose bundle, and nearly every icon probe misses by design. Resolved off-thread now.
14. **Only the mod grid was warmed**, so arriving at any other page paid for it. Warming every page took the worst section frame from **195 ms to 48 ms**.
15. **The mod grid rebuilt a card's whole node tree** for each card scrolling in. A card costs ~2 ms to arrive and only 0.26 ms of that is composing it, so the grid reuses them now.
16. **Hovering a card recomposed the entire card**, both gradients, both labels and the icon, for a change only the favourite star cares about. Crossing the grid did that to every card.
17. **Searching the registry copied it.** `upsert` copied 138 entries and scanned them linearly, once per tree, on every open, and the HUD card lookups did the same once per card.
18. **The keybind conflict map compared every bound key against every other**, per row, per recomposition. Computed once now and held until something actually changes.
19. **The accent colour waited on a frame forever.** Compose reads a pending frame clock awaiter as pending work, so every frame came back dirty. It only waits now if the accent animates.
20. **Scroll edge gradients were rebuilt every frame** on every scrollable surface in the UI. They only depend on the size, so they are built in the draw cache instead.
21. **A card drew its two decorations in two nodes**, costing every card an extra layout node and an extra draw node.
22. **HUD previews were thrown away when the UI closed**, so every reopen rebuilt them. They have their own clock now, ticked only while something is showing them, so keeping them is free.
23. **The HUD editor was rebuilt on every open**, the most expensive open OneConfig has. It is retained like the main screen.
24. **Packet and entity render events allocated even when nothing listened.** They fire thousands of times a second and every one of those was immediately garbage.
25. **Config writes threw to find out whether a type could be written through**, filling in a stack trace per write for the length of a slider drag. Settled once now.
26. **The reflective collector walked up into `Object`**, reflecting over its eleven methods for every config at every nesting level.
27. **The class warm list was 51 names typed by hand** and five had gone stale, so it warmed nothing. It is read off our own jars now.
28. **The shell's glow opacity was read inside the draw**, which makes the layer depend on it, and the shell background is the one thing drawn on every frame of every page.

</details>

<details>
<summary><b>12 bugs fixed</b> (click to expand, ranked worst first)</summary>

1. **Upstream's Kotlin 2.4 bump renamed every internal member's JVM name**, and PolyPlus stopped linking at the first frame that touched a theme. No UI, no main menu, blank screen.
2. **The retained shell changed the shape of its modifier chain when hidden.** Compose indexes those nodes for hit testing, and toggling one desynchronised the index and took the scene down.
3. **Snapshot writes were applied twice inside one frame**, handing new state to a tree already composed against the old. That was the shape of every remaining `RectList` crash.
4. **The scene could be handed a frame time earlier than the last one**, which walks animations backwards and leaves the tree in a state Compose does not expect.
5. **Two callers racing for a thread pool each built one and leaked one**, and the scheduled pool asked for a negative thread count on any machine with fewer than three cores.
6. **The event handler map was not concurrent.** Packet events post from the netty loop, so a handler registered on the main thread could stay hidden indefinitely.
7. **Icon warming submitted a fresh background pass every call**, so several went through the class loader at once, contending with each other and with the render thread doing the same lookups.
8. **Retaining the screen left the nav controller alive across a close**, so returning to the start page assumed it was already there instead of navigating.
9. **The reflective collector logged the tree's id while reporting the tree was null**, so the error path threw instead of explaining itself.
10. **The search results list had stopped being lazy** and dropped a column.
11. **The F3 overlay blanked for one frame** whenever a screen closed.
12. **Config writes asked whether the declared field type could be written through**, not the actual value's. A field declared as an interface reports immutable, so collections were replaced instead of written through and anything holding the old one stopped seeing updates.

</details>

## What this is

UI performance work on the Compose interface, plus the bugs found while doing it.

## Why

On a 141 mod pack the interface was costing between a third and a half of every
frame while it was on screen, and single frames were reaching 190 to 327 ms.

Everything below was measured before and after by a scripted controlled run doing the same
thing every time (three opens, a tour of every page, a slow scroll and two flicks,
three HUD editor opens) on three machines. The harness itself is not part of this
PR.

### Worst single frame, ms, before to after

| area | RTX 3060 | RX 5700 XT | Apple M1 |
|---|---|---|---|
| opening the menu | 190 → 64 | 223 → 105 | 84 → 39 |
| moving between pages | 188 → 49 | 184 → 33 | 121 → 43 |
| scrolling the mod list | 327 → 33 | 115 → 47 | not measured |
| the HUD editor | 116 → 52 | 92 → 36 | 38 → 18 |
| closing the menu | 33 → 47 | 81 → 25 | 24 → 18 |

### What OneConfig cost per frame, ms

A 60 fps frame has 16.7 ms in total.

| area | RTX 3060 | RX 5700 XT | Apple M1 |
|---|---|---|---|
| opening the menu | 6.84 → 3.89 | 10.75 → 3.33 | 4.13 → 2.42 |
| moving between pages | 3.51 → 3.02 | 3.33 → 1.91 | 3.14 → 2.36 |
| scrolling the mod list | 4.02 → 1.93 | 2.11 → 1.33 | not measured |
| the HUD editor | 1.64 → 1.24 | 1.13 → 0.71 | 0.88 → 0.42 |
| closing the menu | 1.04 → 0.97 | 2.04 → 0.85 | 0.62 → 0.55 |

Frames past 33 ms that we caused: 32 → 5, 45 → 7, 19 → 3.
Frames past 50 ms: 28 → 2, 28 → 1, 4 → 0.

## The larger pieces

**The screen and its scene are reused.** Composing, laying out and drawing the tree
is nearly all of what an open costs. Reopening went from ~72 ms to ~9 ms. This is
the change with the most surface area: a retained composition needs the interface
asked to raise its visibility again, the close state reset, and the shell's stale
bounds cleared so they stop answering hit tests.

**The UI is built on the title screen.** The old warm-up ran on the first frame it
could, when the window is still 854x480 and most mods have not registered, so the
first real open paid 197 ms to redo it. It now watches until the inputs settle and
warms a frame at a time rather than landing as one 1332 ms frame.

**Icons are rasterised once.** Compose's bitmap painter built and destroyed a native
image per draw and the mod list draws over a hundred a frame; the finalisers held
the render thread for 320 ms.

**HUD previews stopped redrawing the whole interface.** A HUD reads live values and
those reads happened inside a draw scope, which makes the layer depend on them, so
a ticking clock invalidated everything.

## Bugs fixed

- Kotlin 2.4 renamed every internal member's JVM name, breaking downstream mods
  that link against them (PolyPlus: no UI, blank main menu). The module name is
  pinned to the archives name.
- Snapshot writes applied twice in one frame, handing new state to a tree already
  composed against the old.
- A modifier chain that changed shape when hidden desynchronised Compose's hit
  test index and took the scene down.
- The scene could be handed a frame time earlier than the last one, walking
  animations backwards.
- Two callers racing for a thread pool each built one and leaked one; the
  scheduled pool asked for a negative thread count under three cores.
- The event handler map was not concurrent, though packet events post from the
  netty loop.
- The F3 overlay and the legacy HUD blanked for a frame on screen close.
- The search results list had stopped being lazy and dropped a column.

## Two behaviour changes

- The HUD editor and the config screen are now single reused instances rather than
  constructed per open. `OneConfigUIScreen.open()` replaces `OneConfigUIScreen()`
  at the call sites that want the shared one; a per-mod screen is still constructed
  and is deliberately not retained.
- Closing no longer releases the offscreen render targets. They are viewport sized
  and rebuilt on resize, so releasing them only made the next open pay for a fresh
  texture, framebuffer and Skia surface.

## Known problems with the mod, not fixed

- The mods page still redraws itself ~25 times a second after everything settles,
  where other pages sit at 0 or 1.
- On Apple Silicon the dominant cost is the GPU submit, not drawing. macOS runs GL
  through Metal and a Skia flush there can block on the game's queued work, this is in every case and run to run variance is significant plus I dont own a damn APPLE product. That path is untouched by this PR.