### PR TITLE
fix(keybinds): handle OneConfig mouse binds

### DIFF
--- a/minecraft/src/main/kotlin/org/polyfrost/oneconfig/internal/ui/compose/ComposeScreen.kt
+++ b/minecraft/src/main/kotlin/org/polyfrost/oneconfig/internal/ui/compose/ComposeScreen.kt
@@ -497,7 +497,7 @@ abstract class ComposeScreen(
     //? } else {
     /*override fun mouseClicked(x: Double, y: Double, button: Int): Boolean {
     *///? }
-        if (handleMouseClicked(button)) {
+        if (KeybindRecordingBus.consumeMouse(button, true) || handleMouseClicked(button)) {
             consumedButtons += button
             return true
         }
@@ -516,7 +516,11 @@ abstract class ComposeScreen(
     //? } else {
     /*override fun mouseReleased(x: Double, y: Double, button: Int): Boolean {
     *///? }
-        if (!consumedButtons.remove(button)) sendMouseButtonEvent(PointerEventType.Release, button)
+        val recordingConsumed = KeybindRecordingBus.consumeMouse(button, false)
+        val pressConsumed = consumedButtons.remove(button)
+        if (!recordingConsumed && !pressConsumed) {
+            sendMouseButtonEvent(PointerEventType.Release, button)
+        }
 
         //? if >= 1.21.10 {
         return super.mouseReleased(event)

--- a/minecraft/src/main/kotlin/org/polyfrost/oneconfig/internal/ui/compose/ComposeScreen.kt
+++ b/minecraft/src/main/kotlin/org/polyfrost/oneconfig/internal/ui/compose/ComposeScreen.kt
@@ -538,8 +538,17 @@ abstract class ComposeScreen(
         withScene {
             it.sendPointerEvent(
                 type,
+                //? if sdl_keycodes {
+                /*button = when (button) {
+                    InputConstants.MOUSE_BUTTON_LEFT -> PointerButton.Primary
+                    InputConstants.MOUSE_BUTTON_RIGHT -> PointerButton.Secondary
+                    InputConstants.MOUSE_BUTTON_MIDDLE -> PointerButton.Tertiary
+                    else -> PointerButton(button - 1)
+                }
+                *///?} else {
                 // PointerButton indices match GLFW button numbers (Primary = 0, Secondary = 1, ...)
                 button = if (button >= 0) PointerButton(button) else null,
+                //?}
                 position = pointerPosition()
             )
         }

--- a/minecraft/src/main/kotlin/org/polyfrost/oneconfig/internal/ui/compose/impls/HudEditorUIScreen.kt
+++ b/minecraft/src/main/kotlin/org/polyfrost/oneconfig/internal/ui/compose/impls/HudEditorUIScreen.kt
@@ -16,8 +16,11 @@ import androidx.lifecycle.compose.LocalLifecycleOwner
 import androidx.lifecycle.viewmodel.compose.LocalViewModelStoreOwner
 import com.mojang.blaze3d.platform.InputConstants
 import net.minecraft.client.gui.GuiGraphicsExtractor
+//? if < 1.21.11
+//import org.lwjgl.glfw.GLFW
 import org.polyfrost.oneconfig.api.hud.v1.HudManager
 import org.polyfrost.oneconfig.api.platform.v1.Platform
+import org.polyfrost.oneconfig.api.ui.v1.keybind.KeybindManager
 import org.polyfrost.oneconfig.internal.OneConfigConfig
 import org.polyfrost.oneconfig.internal.ui.compose.ComposeScreen
 import org.polyfrost.oneconfig.internal.ui.guiCloseAnimationMillis
@@ -78,6 +81,19 @@ class HudEditorUIScreen : ComposeScreen() {
         super.removed()
     }
 
+    private fun handleOneConfigKeybind(): Boolean {
+        if (closeRequested) return cancelClose()
+        if (OneConfigConfig.keybindClosesGui) {
+            OneConfigConfig.notifyKeybindClosedGui()
+            beginClose()
+            requestCloseCallback?.invoke()
+        } else {
+            returningToOneConfig = true
+            Platform.screen().display(OneConfigUIScreen())
+        }
+        return true
+    }
+
     override fun handleKeyPressed(key: Int, modifiers: Int): Boolean {
         if (key == InputConstants.KEY_ESCAPE) {
             if (!closeRequested) {
@@ -88,16 +104,19 @@ class HudEditorUIScreen : ComposeScreen() {
         }
         val toggleKey = OneConfigConfig.oneConfigKeybind.keyCodes?.firstOrNull()
         if (toggleKey != null && key == toggleKey && !KeybindRecordingBus.isRecording) {
-            if (closeRequested) return cancelClose()
-            if (OneConfigConfig.keybindClosesGui) {
-                OneConfigConfig.notifyKeybindClosedGui()
-                beginClose()
-                requestCloseCallback?.invoke()
-            } else {
-                returningToOneConfig = true
-                Platform.screen().display(OneConfigUIScreen())
-            }
-            return true
+            return handleOneConfigKeybind()
+        }
+        return false
+    }
+
+    override fun handleMouseClicked(button: Int): Boolean {
+        if (KeybindRecordingBus.isRecording) return false
+        // Only side and extra mouse buttons can trigger the OneConfig keybind
+        //~ if < 1.21.11 'InputConstants.MOUSE_BUTTON_4' -> 'GLFW.GLFW_MOUSE_BUTTON_4'
+        if (button >= InputConstants.MOUSE_BUTTON_4 &&
+            KeybindManager.isTriggeredByMouse(OneConfigConfig.oneConfigKeybind, button)
+        ) {
+            return handleOneConfigKeybind()
         }
         return false
     }

--- a/minecraft/src/main/kotlin/org/polyfrost/oneconfig/internal/ui/compose/impls/OneConfigUIScreen.kt
+++ b/minecraft/src/main/kotlin/org/polyfrost/oneconfig/internal/ui/compose/impls/OneConfigUIScreen.kt
@@ -9,6 +9,7 @@ import net.minecraft.client.gui.GuiGraphicsExtractor
 import org.polyfrost.oneconfig.api.config.v1.ConfigManager
 import org.polyfrost.oneconfig.api.config.v1.Tree
 import org.polyfrost.oneconfig.api.hud.v1.HudManager
+import org.polyfrost.oneconfig.api.ui.v1.keybind.KeybindManager
 import org.polyfrost.oneconfig.internal.OneConfigConfig
 import org.polyfrost.oneconfig.internal.ui.keybind.KeybindRecordingBus
 import org.polyfrost.oneconfig.internal.ui.api.ConfigRegistry
@@ -230,6 +231,18 @@ class OneConfigUIScreen @JvmOverloads constructor(
 
     override fun isPauseScreen(): Boolean = OneConfigConfig.pauseGame
 
+    private fun handleOneConfigKeybind(): Boolean {
+        if (closeRequested) return cancelClose()
+        if (OneConfigConfig.keybindClosesGui) {
+            OneConfigConfig.notifyKeybindClosedGui()
+            beginClose()
+            requestCloseCallback?.invoke()
+        } else {
+            HudManager.openEditor()
+        }
+        return true
+    }
+
     override fun handleKeyPressed(key: Int, modifiers: Int): Boolean {
         if (key == InputConstants.KEY_ESCAPE) {
             if (!closeRequested) {
@@ -240,15 +253,7 @@ class OneConfigUIScreen @JvmOverloads constructor(
         }
         val toggleKey = OneConfigConfig.oneConfigKeybind.keyCodes?.firstOrNull()
         if (toggleKey != null && key == toggleKey && !KeybindRecordingBus.isRecording) {
-            if (closeRequested) return cancelClose()
-            if (OneConfigConfig.keybindClosesGui) {
-                OneConfigConfig.notifyKeybindClosedGui()
-                beginClose()
-                requestCloseCallback?.invoke()
-            } else {
-                HudManager.openEditor()
-            }
-            return true
+            return handleOneConfigKeybind()
         }
         return false
     }
@@ -256,16 +261,25 @@ class OneConfigUIScreen @JvmOverloads constructor(
     /** Mouse side buttons navigate the page history like a browser */
     override fun handleMouseClicked(button: Int): Boolean {
         if (KeybindRecordingBus.isRecording) return false
+        // Only side and extra mouse buttons can trigger the OneConfig keybind
+        //~ if < 1.21.11 'InputConstants.MOUSE_BUTTON_4' -> 'GLFW.GLFW_MOUSE_BUTTON_4'
+        if (button >= InputConstants.MOUSE_BUTTON_4 &&
+            KeybindManager.isTriggeredByMouse(OneConfigConfig.oneConfigKeybind, button)
+        ) {
+            return handleOneConfigKeybind()
+        }
         if (!closeRequested && LocalNavController.isReady) {
             when (button) {
                 //~ if < 1.21.11 'InputConstants.MOUSE_BUTTON_4' -> 'GLFW.GLFW_MOUSE_BUTTON_4'
                 InputConstants.MOUSE_BUTTON_4 -> {
+                    if (KeybindManager.hasTriggeredMouseBind(button)) return true
                     UiSounds.play(UiSoundEvent.CLICK)
                     LocalNavController.wrapper.back()
                     return true
                 }
                 //~ if < 1.21.11 'InputConstants.MOUSE_BUTTON_5' -> 'GLFW.GLFW_MOUSE_BUTTON_5'
                 InputConstants.MOUSE_BUTTON_5 -> {
+                    if (KeybindManager.hasTriggeredMouseBind(button)) return true
                     UiSounds.play(UiSoundEvent.CLICK)
                     LocalNavController.wrapper.forward()
                     return true

--- a/modules/internal/src/main/kotlin/org/polyfrost/oneconfig/internal/ui/components/settings/KeybindOption.kt
+++ b/modules/internal/src/main/kotlin/org/polyfrost/oneconfig/internal/ui/components/settings/KeybindOption.kt
@@ -19,7 +19,6 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
-import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
@@ -31,11 +30,8 @@ import androidx.compose.ui.input.key.key
 import androidx.compose.ui.input.key.onKeyEvent
 import androidx.compose.ui.input.key.type
 import androidx.compose.ui.input.key.utf16CodePoint
-import androidx.compose.ui.input.pointer.PointerEventPass
-import androidx.compose.ui.input.pointer.PointerEventType
 import androidx.compose.ui.input.pointer.PointerIcon
 import androidx.compose.ui.input.pointer.pointerHoverIcon
-import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import org.polyfrost.oneconfig.api.config.v1.Property
@@ -120,8 +116,6 @@ private fun KeyEvent.awtKeyEventId(): Int? = runCatching {
     (field.get(internal) as? java.awt.event.KeyEvent)?.id
 }.getOrNull()
 
-// PointerEvent.button is experimental but the only way to tell which mouse button was pressed
-@OptIn(ExperimentalComposeUiApi::class)
 @Composable
 fun KeybindOption(data: KeybindOptionData) {
     val theme = LocalTheme.current
@@ -204,8 +198,28 @@ fun KeybindOption(data: KeybindOptionData) {
                 applyKeybind(null, null)
                 recording = false
             }
+            val mouseHandler: (Int, Boolean) -> Unit = { button, pressed ->
+                if (pressed) {
+                    if (singleKey) {
+                        applyKeybind(null, intArrayOf(button))
+                        recording = false
+                    } else {
+                        if (button !in recordedMouse) recordedMouse.add(button)
+                        heldMouse.add(button)
+                    }
+                } else {
+                    heldMouse.remove(button)
+                    if (heldKeys.isEmpty() && heldMouse.isEmpty() && (recordedKeys.isNotEmpty() || recordedMouse.isNotEmpty())) {
+                        commitRecording()
+                    }
+                }
+            }
             KeybindRecordingBus.setEscapeHandler(handler)
-            onDispose { KeybindRecordingBus.clearEscapeHandler(handler) }
+            KeybindRecordingBus.setMouseHandler(mouseHandler)
+            onDispose {
+                KeybindRecordingBus.clearEscapeHandler(handler)
+                KeybindRecordingBus.clearMouseHandler(mouseHandler)
+            }
         } else {
             onDispose { }
         }
@@ -260,36 +274,6 @@ fun KeybindOption(data: KeybindOptionData) {
             .focusable()
             .background(bgColor, KeybindShape)
             .border(1.dp, borderColor, KeybindShape)
-            // while recording, mouse buttons pressed on the option are captured as part of the bind
-            // the Initial pass consumes them before clickable can toggle recording off
-            .pointerInput(data.prop) {
-                awaitPointerEventScope {
-                    while (true) {
-                        val event = awaitPointerEvent(PointerEventPass.Initial)
-                        if (!recording) continue
-                        val button = event.button?.index ?: continue
-                        when (event.type) {
-                            PointerEventType.Press -> {
-                                event.changes.forEach { it.consume() }
-                                if (singleKey) {
-                                    applyKeybind(null, intArrayOf(button))
-                                    recording = false
-                                } else {
-                                    if (button !in recordedMouse) recordedMouse.add(button)
-                                    heldMouse.add(button)
-                                }
-                            }
-                            PointerEventType.Release -> {
-                                event.changes.forEach { it.consume() }
-                                heldMouse.remove(button)
-                                if (heldKeys.isEmpty() && heldMouse.isEmpty() && (recordedKeys.isNotEmpty() || recordedMouse.isNotEmpty())) {
-                                    commitRecording()
-                                }
-                            }
-                        }
-                    }
-                }
-            }
             .onClick(interactionSource) { if (!recording) recording = true }
             .pointerHoverIcon(PointerIcon.Hand)
             .padding(horizontal = 12.dp, vertical = 7.dp),

--- a/modules/internal/src/main/kotlin/org/polyfrost/oneconfig/internal/ui/keybind/KeybindRecordingBus.kt
+++ b/modules/internal/src/main/kotlin/org/polyfrost/oneconfig/internal/ui/keybind/KeybindRecordingBus.kt
@@ -4,12 +4,23 @@ object KeybindRecordingBus {
     @Volatile
     private var escapeHandler: (() -> Unit)? = null
 
+    @Volatile
+    private var mouseHandler: ((Int, Boolean) -> Unit)? = null
+
     fun setEscapeHandler(handler: () -> Unit) {
         escapeHandler = handler
     }
 
     fun clearEscapeHandler(handler: () -> Unit) {
         if (escapeHandler === handler) escapeHandler = null
+    }
+
+    fun setMouseHandler(handler: (Int, Boolean) -> Unit) {
+        mouseHandler = handler
+    }
+
+    fun clearMouseHandler(handler: (Int, Boolean) -> Unit) {
+        if (mouseHandler === handler) mouseHandler = null
     }
 
     @JvmStatic
@@ -19,6 +30,13 @@ object KeybindRecordingBus {
     fun consumeEscape(): Boolean {
         val handler = escapeHandler ?: return false
         handler()
+        return true
+    }
+
+    @JvmStatic
+    fun consumeMouse(button: Int, pressed: Boolean): Boolean {
+        val handler = mouseHandler ?: return false
+        handler(button, pressed)
         return true
     }
 }

--- a/modules/ui/api/ui.api
+++ b/modules/ui/api/ui.api
@@ -174,7 +174,9 @@ public final class org/polyfrost/oneconfig/api/ui/v1/keybind/KeybindManager {
 	public static final fun addRebindListener (Lkotlin/jvm/functions/Function2;)V
 	public static final fun builder ()Lorg/polyfrost/oneconfig/api/ui/v1/keybind/KeybindHelper;
 	public static final fun findConflicts (Lorg/polyfrost/oneconfig/api/ui/v1/keybind/OneConfigKeybind;)Ljava/util/List;
+	public static final fun hasTriggeredMouseBind (I)Z
 	public static final fun isRegistered (Lorg/polyfrost/oneconfig/api/ui/v1/keybind/OneConfigKeybind;)Z
+	public static final fun isTriggeredByMouse (Lorg/polyfrost/oneconfig/api/ui/v1/keybind/OneConfigKeybind;I)Z
 	public static final fun notifyMenuEdit (Lorg/polyfrost/oneconfig/api/ui/v1/keybind/OneConfigKeybind;)V
 	public static final fun rebindFromMinecraft (Lorg/polyfrost/oneconfig/api/ui/v1/keybind/OneConfigKeybind;[I)Lorg/polyfrost/oneconfig/api/ui/v1/keybind/OneConfigKeybind;
 	public static final fun rebindFromMinecraft (Lorg/polyfrost/oneconfig/api/ui/v1/keybind/OneConfigKeybind;[I[I)Lorg/polyfrost/oneconfig/api/ui/v1/keybind/OneConfigKeybind;

--- a/modules/ui/src/main/kotlin/org/polyfrost/oneconfig/api/ui/v1/keybind/KeybindManager.kt
+++ b/modules/ui/src/main/kotlin/org/polyfrost/oneconfig/api/ui/v1/keybind/KeybindManager.kt
@@ -197,6 +197,15 @@ object KeybindManager {
         return binds.filter { it.conflictsWith(bind) }
     }
 
+    /** True when a registered keybind containing [button] matches the current input state */
+    @JvmStatic
+    fun hasTriggeredMouseBind(button: Int): Boolean = binds.any { isTriggeredByMouse(it, button) }
+
+    /** True when [bind] contains [button] and matches the current input state */
+    @JvmStatic
+    fun isTriggeredByMouse(bind: OneConfigKeybind, button: Int): Boolean =
+        bind.mouseBtns?.contains(button) == true && bind.test(downKeys, downMouse, mods)
+
     @JvmStatic
     fun builder() = KeybindHelper()
 


### PR DESCRIPTION
## Description
Finishes earlier work on mouse button keybind support:
- Mouse buttons are captured anywhere on screen while recording
- Custom side mouse bindings have precedence over hardcoded Oneconfig forward/backwards navigation
- When the oneconfig keybind is bound to a mouse button, it has the same special handling as keyboard bindings

## Related Issue(s)
Closes #949 and #944

## Checklist

- [x] I made a clear description of what was changed
- [x] I stated why these changes were necessary
- [x] I updated documentation or said what needs to be updated
- [x] I made sure these changes are backwards compatible
- [x] This pull request is for one feature/bug fix
