### PR TITLE
fix(bootstrap): actually depend on OneConfig

### DIFF
--- a/bootstrap/src/main/resources/fabric.mod.json
+++ b/bootstrap/src/main/resources/fabric.mod.json
@@ -21,6 +21,7 @@
   "depends": {
     "fabricloader": ">=0.12.0",
     "minecraft": "${mc_version}",
+    "oneconfigv1": "${mod_version}",
     "compose-multiplatform": ">=1.0.4",
     "fabric-language-kotlin": ">=1.13.13+kotlin.2.4.10"
   }


### PR DESCRIPTION
## Description
Previously if a dep declared by minecraft module was missing, `oneconfigv1` would just get silently dropped.