### PR TITLE
fix: release search focus after warm up

### DIFF
--- a/minecraft/src/main/kotlin/org/polyfrost/oneconfig/internal/ui/compose/ComposeScreen.kt
+++ b/minecraft/src/main/kotlin/org/polyfrost/oneconfig/internal/ui/compose/ComposeScreen.kt
@@ -375,6 +375,10 @@ abstract class ComposeScreen(
     }
 
     fun endPrewarm() {
+        if (prewarmCursor > 0) {
+            // Release hidden search focus so it doesn't suppress keybinds
+            withScene { it.focusManager.releaseFocus() }
+        }
         prewarmCursor = 0
         releasePrewarmSurface()
     }
@@ -427,8 +431,7 @@ abstract class ComposeScreen(
         }
         sceneDirty = true
         if (prewarmCursor < frames) return false
-        prewarmCursor = 0
-        releasePrewarmSurface()
+        endPrewarm()
         return true
     }
 

--- a/minecraft/src/main/kotlin/org/polyfrost/oneconfig/internal/ui/compose/impls/OneConfigUIScreen.kt
+++ b/minecraft/src/main/kotlin/org/polyfrost/oneconfig/internal/ui/compose/impls/OneConfigUIScreen.kt
@@ -231,6 +231,7 @@ class OneConfigUIScreen @JvmOverloads constructor(
                 }
             }
         } catch (t: Throwable) {
+            endPrewarm()
             LOGGER.warn("OneConfig UI warm-up failed; the first open will build the UI instead", t)
             false
         } finally {

--- a/modules/hud/api/hud.api
+++ b/modules/hud/api/hud.api
@@ -274,6 +274,7 @@ public final class org/polyfrost/oneconfig/api/hud/v1/HudManager {
 	public final fun getHudsOfType (Ljava/lang/Class;)Ljava/util/ArrayList;
 	public final fun getPreviewRevision ()Landroidx/compose/runtime/MutableIntState;
 	public final fun getProvider (Ljava/lang/Class;)Lorg/polyfrost/oneconfig/api/hud/v1/Hud;
+	public final fun getRenderRevision ()Landroidx/compose/runtime/MutableIntState;
 	public final fun getRevision ()I
 	public final fun hasHudOfType (Ljava/lang/Class;)Z
 	public final fun iconFor (Ljava/lang/String;)Ljava/lang/String;

--- a/modules/hud/src/main/kotlin/org/polyfrost/oneconfig/api/hud/v1/HudManager.kt
+++ b/modules/hud/src/main/kotlin/org/polyfrost/oneconfig/api/hud/v1/HudManager.kt
@@ -157,6 +157,9 @@ object HudManager {
     val previewRevision = mutableIntStateOf(0)
 
     @ApiStatus.Internal
+    val renderRevision = mutableIntStateOf(0)
+
+    @ApiStatus.Internal
     val editorOpenRevision = mutableIntStateOf(0)
 
     private val redrawCacheDisabled = java.lang.Boolean.getBoolean("oneconfig.hud.nocache")
@@ -488,7 +491,10 @@ object HudManager {
             }
         }
         if (showingPreviews) for (hud in hudProviders.values) updateIfDue(hud)
-        if (PolyComposeHost.frameWithReport()) invalidate()
+        if (PolyComposeHost.frameWithReport()) {
+            invalidate()
+            renderRevision.intValue++
+        }
         if (showingPreviews) {
             PolyComposeHost.previews.frame(notify = false)
             if (PolyComposeHost.previews.appliedChange) previewRevision.intValue++

--- a/modules/internal/src/main/kotlin/org/polyfrost/oneconfig/internal/ui/hud/screens/HudDesignStudio.kt
+++ b/modules/internal/src/main/kotlin/org/polyfrost/oneconfig/internal/ui/hud/screens/HudDesignStudio.kt
@@ -412,12 +412,9 @@ private fun hitTestAnchorPoint(
     return best
 }
 
-private fun drawHudContents(sk: org.jetbrains.skia.Canvas, mcToScreen: Float) =
-    androidx.compose.runtime.snapshots.Snapshot.withoutReadObservation {
-        drawHudContentsNow(sk, mcToScreen)
-    }
-
-private fun drawHudContentsNow(sk: org.jetbrains.skia.Canvas, mcToScreen: Float) {
+private fun drawHudContents(sk: org.jetbrains.skia.Canvas, mcToScreen: Float) {
+    HudManager.renderRevision.intValue
+    HudManager.revision
     // HUDs fused with a neighbour do not paint their own background so the merged shapes are laid down
     // here first just like the in-game HUD pass
     sk.save()


### PR DESCRIPTION
## Description
- HUDs behind OneConfig menu now invalidate cache properly
- Fixes hidden search focus not being released after warm up, causing OneConfig keybind to not work (current warmup timing avoids this issue, but becomes problem if warmup timing is changed like in 1.8)

## Checklist

- [x] I made a clear description of what was changed
- [x] I stated why these changes were necessary
- [x] I updated documentation or said what needs to be updated
- [x] I made sure these changes are backwards compatible
- [x] This pull request is for one feature/bug fix
