### PR TITLE
fix(ui): prevent opening animation flicker

### DIFF
--- a/modules/internal/src/main/kotlin/org/polyfrost/oneconfig/internal/ui/components/RetainedVisibility.kt
+++ b/modules/internal/src/main/kotlin/org/polyfrost/oneconfig/internal/ui/components/RetainedVisibility.kt
@@ -20,13 +20,8 @@ fun RetainedVisibility(
     openKey: Any? = null,
     content: @Composable (alpha: Float) -> Unit,
 ) {
-    val progress = remember { Animatable(if (visible) 1f else 0f) }
-    val lastKey = remember { arrayOf(openKey) }
+    val progress = remember(openKey) { Animatable(0f) }
     LaunchedEffect(openKey, visible) {
-        if (openKey != lastKey[0]) {
-            progress.snapTo(0f)
-            lastKey[0] = openKey
-        }
         progress.animateTo(if (visible) 1f else 0f, if (visible) enter else exit)
     }
 


### PR DESCRIPTION
Fixes this one frame flicker on first open, regression from bc83fc34dceec2eacd3e05c7adc751bf83ab24a8:

https://github.com/user-attachments/assets/3f706be5-6d93-4ffa-8428-2ff49a43a3b2

